### PR TITLE
Add support for certificate chains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ go:
     - 1.8
     - tip
 before_install:
-    - go get -u github.com/golang/lint/golint
+    - make gettools
 script:
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 go:
     - 1.6
     - 1.7
+    - 1.8
     - tip
-go_import_path: go.mozilla.org/pkcs7
 before_install:
     - go get -u github.com/golang/lint/golint
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,26 @@
-PROJECT := go.mozilla.org/pkcs7
-
-all: test vet lint
+all: vet lint unused gosimple staticcheck test
 
 test:
-	go test -covermode=count -coverprofile=coverage.out $(PROJECT)
+	go test -covermode=count -coverprofile=coverage.out .
 
 showcoverage: test
 	go tool cover -html=coverage.out
 
 vet:
-	go vet $(PROJECT)
+	go vet .
 
 lint:
-	golint $(PROJECT)
+	golint .
+
+unused:
+	unused .
+
+gosimple:
+	gosimple .
+
+staticcheck:
+	staticcheck .
+
+gettools:
+	go get -u honnef.co/go/tools/...
+	go get -u github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ PROJECT := go.mozilla.org/pkcs7
 all: test vet lint
 
 test:
-	go test $(PROJECT)
+	go test -covermode=count -coverprofile=coverage.out $(PROJECT)
+
+showcoverage: test
+	go tool cover -html=coverage.out
 
 vet:
 	go vet $(PROJECT)

--- a/ber.go
+++ b/ber.go
@@ -1,4 +1,4 @@
-package pkcs7 // import "go.mozilla.org/pkcs7"
+package pkcs7
 
 import (
 	"bytes"

--- a/ber.go
+++ b/ber.go
@@ -150,7 +150,8 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 				return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
 			}
 		}
-		tag = tag*128 + ber[offset] - 0x80
+		// jvehent 20170227: this doesn't appear to be used anywhere...
+		//tag = tag*128 + ber[offset] - 0x80
 		offset++
 		if offset > berLen {
 			return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
@@ -159,13 +160,11 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	tagEnd := offset
 
 	kind := b & 0x20
-	/*
-		if kind == 0 {
-			fmt.Print("--> Primitive\n")
-		} else {
-			fmt.Print("--> Constructed\n")
-		}
-	*/
+	if kind == 0 {
+		debugprint("--> Primitive\n")
+	} else {
+		debugprint("--> Constructed\n")
+	}
 	// read length
 	var length int
 	l := ber[offset]
@@ -185,8 +184,8 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		if 0x0 == (int)(ber[offset]) {
 			return nil, 0, errors.New("ber2der: BER tag length has leading zero")
 		}
-		//fmt.Printf("--> (compute length) indicator byte: %x\n", l)
-		//fmt.Printf("--> (compute length) length bytes: % X\n", ber[offset:offset+numberOfBytes])
+		debugprint("--> (compute length) indicator byte: %x\n", l)
+		debugprint("--> (compute length) length bytes: % X\n", ber[offset:offset+numberOfBytes])
 		for i := 0; i < numberOfBytes; i++ {
 			length = length*256 + (int)(ber[offset])
 			offset++
@@ -202,7 +201,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		}
 		length = markerIndex
 		hack = 2
-		//fmt.Printf("--> (compute length) marker found at offset: %d\n", markerIndex+offset)
+		debugprint("--> (compute length) marker found at offset: %d\n", markerIndex+offset)
 	} else {
 		length = (int)(l)
 	}
@@ -214,9 +213,9 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	if contentEnd > len(ber) {
 		return nil, 0, errors.New("ber2der: BER tag length is more than available data")
 	}
-	//fmt.Printf("--> content start : %d\n", offset)
-	//fmt.Printf("--> content end   : %d\n", contentEnd)
-	//fmt.Printf("--> content       : % X\n", ber[offset:contentEnd])
+	debugprint("--> content start : %d\n", offset)
+	debugprint("--> content end   : %d\n", contentEnd)
+	debugprint("--> content       : % X\n", ber[offset:contentEnd])
 	var obj asn1Object
 	if kind == 0 {
 		obj = asn1Primitive{
@@ -242,4 +241,8 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	}
 
 	return obj, contentEnd + hack, nil
+}
+
+func debugprint(format string, a ...interface{}) {
+	//fmt.Printf(format, a)
 }

--- a/ber_test.go
+++ b/ber_test.go
@@ -1,4 +1,4 @@
-package pkcs7 // import "go.mozilla.org/pkcs7"
+package pkcs7
 
 import (
 	"bytes"

--- a/ber_test.go
+++ b/ber_test.go
@@ -15,7 +15,7 @@ func TestBer2Der(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ber2der failed with error: %v", err)
 	}
-	if bytes.Compare(der, expected) != 0 {
+	if !bytes.Equal(der, expected) {
 		t.Errorf("ber2der result did not match.\n\tExpected: % X\n\tActual: % X", expected, der)
 	}
 

--- a/decrypt.go
+++ b/decrypt.go
@@ -1,0 +1,166 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+)
+
+// ErrUnsupportedAlgorithm tells you when our quick dev assumptions have failed
+var ErrUnsupportedAlgorithm = errors.New("pkcs7: cannot decrypt data: only RSA, DES, DES-EDE3, AES-256-CBC and AES-128-GCM supported")
+
+// ErrNotEncryptedContent is returned when attempting to Decrypt data that is not encrypted data
+var ErrNotEncryptedContent = errors.New("pkcs7: content data is a decryptable data type")
+
+// Decrypt decrypts encrypted content info for recipient cert and private key
+func (p7 *PKCS7) Decrypt(cert *x509.Certificate, pkey crypto.PrivateKey) ([]byte, error) {
+	data, ok := p7.raw.(envelopedData)
+	if !ok {
+		return nil, ErrNotEncryptedContent
+	}
+	recipient := selectRecipientForCertificate(data.RecipientInfos, cert)
+	if recipient.EncryptedKey == nil {
+		return nil, errors.New("pkcs7: no enveloped recipient for provided certificate")
+	}
+	switch pkey.(type) {
+	case *rsa.PrivateKey:
+		var contentKey []byte
+		contentKey, err := rsa.DecryptPKCS1v15(rand.Reader, pkey.(*rsa.PrivateKey), recipient.EncryptedKey)
+		if err != nil {
+			return nil, err
+		}
+		return data.EncryptedContentInfo.decrypt(contentKey)
+	}
+	return nil, ErrUnsupportedAlgorithm
+}
+
+func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
+	alg := eci.ContentEncryptionAlgorithm.Algorithm
+	if !alg.Equal(oidEncryptionAlgorithmDESCBC) &&
+		!alg.Equal(oidEncryptionAlgorithmDESEDE3CBC) &&
+		!alg.Equal(oidEncryptionAlgorithmAES256CBC) &&
+		!alg.Equal(oidEncryptionAlgorithmAES128CBC) &&
+		!alg.Equal(oidEncryptionAlgorithmAES128GCM) {
+		fmt.Printf("Unsupported Content Encryption Algorithm: %s\n", alg)
+		return nil, ErrUnsupportedAlgorithm
+	}
+
+	// EncryptedContent can either be constructed of multple OCTET STRINGs
+	// or _be_ a tagged OCTET STRING
+	var cyphertext []byte
+	if eci.EncryptedContent.IsCompound {
+		// Complex case to concat all of the children OCTET STRINGs
+		var buf bytes.Buffer
+		cypherbytes := eci.EncryptedContent.Bytes
+		for {
+			var part []byte
+			cypherbytes, _ = asn1.Unmarshal(cypherbytes, &part)
+			buf.Write(part)
+			if cypherbytes == nil {
+				break
+			}
+		}
+		cyphertext = buf.Bytes()
+	} else {
+		// Simple case, the bytes _are_ the cyphertext
+		cyphertext = eci.EncryptedContent.Bytes
+	}
+
+	var block cipher.Block
+	var err error
+
+	switch {
+	case alg.Equal(oidEncryptionAlgorithmDESCBC):
+		block, err = des.NewCipher(key)
+	case alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
+		block, err = des.NewTripleDESCipher(key)
+	case alg.Equal(oidEncryptionAlgorithmAES256CBC):
+		fallthrough
+	case alg.Equal(oidEncryptionAlgorithmAES128GCM), alg.Equal(oidEncryptionAlgorithmAES128CBC):
+		block, err = aes.NewCipher(key)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if alg.Equal(oidEncryptionAlgorithmAES128GCM) {
+		params := aesGCMParameters{}
+		paramBytes := eci.ContentEncryptionAlgorithm.Parameters.Bytes
+
+		_, err := asn1.Unmarshal(paramBytes, &params)
+		if err != nil {
+			return nil, err
+		}
+
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(params.Nonce) != gcm.NonceSize() {
+			return nil, errors.New("pkcs7: encryption algorithm parameters are incorrect")
+		}
+		if params.ICVLen != gcm.Overhead() {
+			return nil, errors.New("pkcs7: encryption algorithm parameters are incorrect")
+		}
+
+		plaintext, err := gcm.Open(nil, params.Nonce, cyphertext, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		return plaintext, nil
+	}
+
+	iv := eci.ContentEncryptionAlgorithm.Parameters.Bytes
+	if len(iv) != block.BlockSize() {
+		return nil, errors.New("pkcs7: encryption algorithm parameters are malformed")
+	}
+	mode := cipher.NewCBCDecrypter(block, iv)
+	plaintext := make([]byte, len(cyphertext))
+	mode.CryptBlocks(plaintext, cyphertext)
+	if plaintext, err = unpad(plaintext, mode.BlockSize()); err != nil {
+		return nil, err
+	}
+	return plaintext, nil
+}
+
+func unpad(data []byte, blocklen int) ([]byte, error) {
+	if blocklen < 1 {
+		return nil, fmt.Errorf("invalid blocklen %d", blocklen)
+	}
+	if len(data)%blocklen != 0 || len(data) == 0 {
+		return nil, fmt.Errorf("invalid data len %d", len(data))
+	}
+
+	// the last byte is the length of padding
+	padlen := int(data[len(data)-1])
+
+	// check padding integrity, all bytes should be the same
+	pad := data[len(data)-padlen:]
+	for _, padbyte := range pad {
+		if padbyte != byte(padlen) {
+			return nil, errors.New("invalid padding")
+		}
+	}
+
+	return data[:len(data)-padlen], nil
+}
+
+func selectRecipientForCertificate(recipients []recipientInfo, cert *x509.Certificate) recipientInfo {
+	for _, recp := range recipients {
+		if isCertMatchForIssuerAndSerial(cert, recp.IssuerAndSerialNumber) {
+			return recp
+		}
+	}
+	return recipientInfo{}
+}

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -1,0 +1,60 @@
+package pkcs7
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDecrypt(t *testing.T) {
+	fixture := UnmarshalTestFixture(EncryptedTestFixture)
+	p7, err := Parse(fixture.Input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := p7.Decrypt(fixture.Certificate, fixture.PrivateKey)
+	if err != nil {
+		t.Errorf("Cannot Decrypt with error: %v", err)
+	}
+	expected := []byte("This is a test")
+	if !bytes.Equal(content, expected) {
+		t.Errorf("Decrypted result does not match.\n\tExpected:%s\n\tActual:%s", expected, content)
+	}
+}
+
+// Content is "This is a test"
+var EncryptedTestFixture = `
+-----BEGIN PKCS7-----
+MIIBFwYJKoZIhvcNAQcDoIIBCDCCAQQCAQAxgcowgccCAQAwMjApMRAwDgYDVQQK
+EwdBY21lIENvMRUwEwYDVQQDEwxFZGRhcmQgU3RhcmsCBQDL+CvWMAsGCSqGSIb3
+DQEBAQSBgKyP/5WlRTZD3dWMrLOX6QRNDrXEkQjhmToRwFZdY3LgUh25ZU0S/q4G
+dHPV21Fv9lQD+q7l3vfeHw8M6Z1PKi9sHMVfxAkQpvaI96DTIT3YHtuLC1w3geCO
+8eFWTq2qS4WChSuS/yhYosjA1kTkE0eLnVZcGw0z/WVuEZznkdyIMDIGCSqGSIb3
+DQEHATARBgUrDgMCBwQImpKsUyMPpQigEgQQRcWWrCRXqpD5Njs0GkJl+g==
+-----END PKCS7-----
+-----BEGIN CERTIFICATE-----
+MIIB1jCCAUGgAwIBAgIFAMv4K9YwCwYJKoZIhvcNAQELMCkxEDAOBgNVBAoTB0Fj
+bWUgQ28xFTATBgNVBAMTDEVkZGFyZCBTdGFyazAeFw0xNTA1MDYwMzU2NDBaFw0x
+NjA1MDYwMzU2NDBaMCUxEDAOBgNVBAoTB0FjbWUgQ28xETAPBgNVBAMTCEpvbiBT
+bm93MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDK6NU0R0eiCYVquU4RcjKc
+LzGfx0aa1lMr2TnLQUSeLFZHFxsyyMXXuMPig3HK4A7SGFHupO+/1H/sL4xpH5zg
+8+Zg2r8xnnney7abxcuv0uATWSIeKlNnb1ZO1BAxFnESc3GtyOCr2dUwZHX5mRVP
++Zxp2ni5qHNraf3wE2VPIQIDAQABoxIwEDAOBgNVHQ8BAf8EBAMCAKAwCwYJKoZI
+hvcNAQELA4GBAIr2F7wsqmEU/J/kLyrCgEVXgaV/sKZq4pPNnzS0tBYk8fkV3V18
+sBJyHKRLL/wFZASvzDcVGCplXyMdAOCyfd8jO3F9Ac/xdlz10RrHJT75hNu3a7/n
+9KNwKhfN4A1CQv2x372oGjRhCW5bHNCWx4PIVeNzCyq/KZhyY9sxHE6f
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+MIICXgIBAAKBgQDK6NU0R0eiCYVquU4RcjKcLzGfx0aa1lMr2TnLQUSeLFZHFxsy
+yMXXuMPig3HK4A7SGFHupO+/1H/sL4xpH5zg8+Zg2r8xnnney7abxcuv0uATWSIe
+KlNnb1ZO1BAxFnESc3GtyOCr2dUwZHX5mRVP+Zxp2ni5qHNraf3wE2VPIQIDAQAB
+AoGBALyvnSt7KUquDen7nXQtvJBudnf9KFPt//OjkdHHxNZNpoF/JCSqfQeoYkeu
+MdAVYNLQGMiRifzZz4dDhA9xfUAuy7lcGQcMCxEQ1dwwuFaYkawbS0Tvy2PFlq2d
+H5/HeDXU4EDJ3BZg0eYj2Bnkt1sJI35UKQSxblQ0MY2q0uFBAkEA5MMOogkgUx1C
+67S1tFqMUSM8D0mZB0O5vOJZC5Gtt2Urju6vywge2ArExWRXlM2qGl8afFy2SgSv
+Xk5eybcEiQJBAOMRwwbEoW5NYHuFFbSJyWll4n71CYuWuQOCzehDPyTb80WFZGLV
+i91kFIjeERyq88eDE5xVB3ZuRiXqaShO/9kCQQCKOEkpInaDgZSjskZvuJ47kByD
+6CYsO4GIXQMMeHML8ncFH7bb6AYq5ybJVb2NTU7QLFJmfeYuhvIm+xdOreRxAkEA
+o5FC5Jg2FUfFzZSDmyZ6IONUsdF/i78KDV5nRv1R+hI6/oRlWNCtTNBv/lvBBd6b
+dseUE9QoaQZsn5lpILEvmQJAZ0B+Or1rAYjnbjnUhdVZoy9kC4Zov+4UH3N/BtSy
+KJRWUR0wTWfZBPZ5hAYZjTBEAFULaYCXlQKsODSp0M1aQA==
+-----END PRIVATE KEY-----`

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,0 +1,249 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+)
+
+type envelopedData struct {
+	Version              int
+	RecipientInfos       []recipientInfo `asn1:"set"`
+	EncryptedContentInfo encryptedContentInfo
+}
+
+type recipientInfo struct {
+	Version                int
+	IssuerAndSerialNumber  issuerAndSerial
+	KeyEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedKey           []byte
+}
+
+type encryptedContentInfo struct {
+	ContentType                asn1.ObjectIdentifier
+	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedContent           asn1.RawValue `asn1:"tag:0,optional,explicit"`
+}
+
+const (
+	// EncryptionAlgorithmDESCBC is the DES CBC encryption algorithm
+	EncryptionAlgorithmDESCBC = iota
+
+	// EncryptionAlgorithmAES128GCM is the AES 128 bits with GCM encryption algorithm
+	EncryptionAlgorithmAES128GCM
+)
+
+// ContentEncryptionAlgorithm determines the algorithm used to encrypt the
+// plaintext message. Change the value of this variable to change which
+// algorithm is used in the Encrypt() function.
+var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
+
+// ErrUnsupportedEncryptionAlgorithm is returned when attempting to encrypt
+// content with an unsupported algorithm.
+var ErrUnsupportedEncryptionAlgorithm = errors.New("pkcs7: cannot encrypt content: only DES-CBC and AES-128-GCM supported")
+
+const nonceSize = 12
+
+type aesGCMParameters struct {
+	Nonce  []byte `asn1:"tag:4"`
+	ICVLen int
+}
+
+func encryptAES128GCM(content []byte) ([]byte, *encryptedContentInfo, error) {
+	// Create AES key and nonce
+	key := make([]byte, 16)
+	nonce := make([]byte, nonceSize)
+
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, err = rand.Read(nonce)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encrypt content
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, content, nil)
+
+	// Prepare ASN.1 Encrypted Content Info
+	paramSeq := aesGCMParameters{
+		Nonce:  nonce,
+		ICVLen: gcm.Overhead(),
+	}
+
+	paramBytes, err := asn1.Marshal(paramSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eci := encryptedContentInfo{
+		ContentType: oidData,
+		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
+			Algorithm: oidEncryptionAlgorithmAES128GCM,
+			Parameters: asn1.RawValue{
+				Tag:   asn1.TagSequence,
+				Bytes: paramBytes,
+			},
+		},
+		EncryptedContent: marshalEncryptedContent(ciphertext),
+	}
+
+	return key, &eci, nil
+}
+
+func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
+	// Create DES key & CBC IV
+	key := make([]byte, 8)
+	iv := make([]byte, des.BlockSize)
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = rand.Read(iv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encrypt padded content
+	block, err := des.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	mode := cipher.NewCBCEncrypter(block, iv)
+	plaintext, err := pad(content, mode.BlockSize())
+	if err != nil {
+		return nil, nil, err
+	}
+	cyphertext := make([]byte, len(plaintext))
+	mode.CryptBlocks(cyphertext, plaintext)
+
+	// Prepare ASN.1 Encrypted Content Info
+	eci := encryptedContentInfo{
+		ContentType: oidData,
+		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
+			Algorithm:  oidEncryptionAlgorithmDESCBC,
+			Parameters: asn1.RawValue{Tag: 4, Bytes: iv},
+		},
+		EncryptedContent: marshalEncryptedContent(cyphertext),
+	}
+
+	return key, &eci, nil
+}
+
+// Encrypt creates and returns an envelope data PKCS7 structure with encrypted
+// recipient keys for each recipient public key.
+//
+// The algorithm used to perform encryption is determined by the current value
+// of the global ContentEncryptionAlgorithm package variable. By default, the
+// value is EncryptionAlgorithmDESCBC. To use a different algorithm, change the
+// value before calling Encrypt(). For example:
+//
+//     ContentEncryptionAlgorithm = EncryptionAlgorithmAES128GCM
+//
+// TODO(fullsailor): Add support for encrypting content with other algorithms
+func Encrypt(content []byte, recipients []*x509.Certificate) ([]byte, error) {
+	var eci *encryptedContentInfo
+	var key []byte
+	var err error
+
+	// Apply chosen symmetric encryption method
+	switch ContentEncryptionAlgorithm {
+	case EncryptionAlgorithmDESCBC:
+		key, eci, err = encryptDESCBC(content)
+
+	case EncryptionAlgorithmAES128GCM:
+		key, eci, err = encryptAES128GCM(content)
+
+	default:
+		return nil, ErrUnsupportedEncryptionAlgorithm
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare each recipient's encrypted cipher key
+	recipientInfos := make([]recipientInfo, len(recipients))
+	for i, recipient := range recipients {
+		encrypted, err := encryptKey(key, recipient)
+		if err != nil {
+			return nil, err
+		}
+		ias, err := cert2issuerAndSerial(recipient)
+		if err != nil {
+			return nil, err
+		}
+		info := recipientInfo{
+			Version:               0,
+			IssuerAndSerialNumber: ias,
+			KeyEncryptionAlgorithm: pkix.AlgorithmIdentifier{
+				Algorithm: oidEncryptionAlgorithmRSA,
+			},
+			EncryptedKey: encrypted,
+		}
+		recipientInfos[i] = info
+	}
+
+	// Prepare envelope content
+	envelope := envelopedData{
+		EncryptedContentInfo: *eci,
+		Version:              0,
+		RecipientInfos:       recipientInfos,
+	}
+	innerContent, err := asn1.Marshal(envelope)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare outer payload structure
+	wrapper := contentInfo{
+		ContentType: oidEnvelopedData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, IsCompound: true, Bytes: innerContent},
+	}
+
+	return asn1.Marshal(wrapper)
+}
+
+func marshalEncryptedContent(content []byte) asn1.RawValue {
+	asn1Content, _ := asn1.Marshal(content)
+	return asn1.RawValue{Tag: 0, Class: 2, Bytes: asn1Content, IsCompound: true}
+}
+
+func encryptKey(key []byte, recipient *x509.Certificate) ([]byte, error) {
+	if pub := recipient.PublicKey.(*rsa.PublicKey); pub != nil {
+		return rsa.EncryptPKCS1v15(rand.Reader, pub, key)
+	}
+	return nil, ErrUnsupportedAlgorithm
+}
+
+func pad(data []byte, blocklen int) ([]byte, error) {
+	if blocklen < 1 {
+		return nil, fmt.Errorf("invalid blocklen %d", blocklen)
+	}
+	padlen := blocklen - (len(data) % blocklen)
+	if padlen == 0 {
+		padlen = blocklen
+	}
+	pad := bytes.Repeat([]byte{byte(padlen)}, padlen)
+	return append(data, pad...), nil
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1,0 +1,66 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto/x509"
+	"testing"
+)
+
+func TestEncrypt(t *testing.T) {
+	modes := []int{
+		EncryptionAlgorithmDESCBC,
+		EncryptionAlgorithmAES128GCM,
+	}
+	sigalgs := []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
+		x509.SHA256WithRSA,
+		x509.SHA512WithRSA,
+	}
+	for _, mode := range modes {
+		for _, sigalg := range sigalgs {
+			ContentEncryptionAlgorithm = mode
+
+			plaintext := []byte("Hello Secret World!")
+			cert, err := createTestCertificate(sigalg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			encrypted, err := Encrypt(plaintext, []*x509.Certificate{cert.Certificate})
+			if err != nil {
+				t.Fatal(err)
+			}
+			p7, err := Parse(encrypted)
+			if err != nil {
+				t.Fatalf("cannot Parse encrypted result: %s", err)
+			}
+			result, err := p7.Decrypt(cert.Certificate, *cert.PrivateKey)
+			if err != nil {
+				t.Fatalf("cannot Decrypt encrypted result: %s", err)
+			}
+			if !bytes.Equal(plaintext, result) {
+				t.Errorf("encrypted data does not match plaintext:\n\tExpected: %s\n\tActual: %s", plaintext, result)
+			}
+		}
+	}
+}
+
+func TestPad(t *testing.T) {
+	tests := []struct {
+		Original  []byte
+		Expected  []byte
+		BlockSize int
+	}{
+		{[]byte{0x1, 0x2, 0x3, 0x10}, []byte{0x1, 0x2, 0x3, 0x10, 0x4, 0x4, 0x4, 0x4}, 8},
+		{[]byte{0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0}, []byte{0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8}, 8},
+	}
+	for _, test := range tests {
+		padded, err := pad(test.Original, test.BlockSize)
+		if err != nil {
+			t.Errorf("pad encountered error: %s", err)
+			continue
+		}
+		if !bytes.Equal(test.Expected, padded) {
+			t.Errorf("pad results mismatch:\n\tExpected: %X\n\tActual: %X", test.Expected, padded)
+		}
+	}
+}

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -4,21 +4,14 @@ package pkcs7
 import (
 	"bytes"
 	"crypto"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/des"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/rsa"
-	"crypto/subtle"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
-	"time"
 
 	_ "crypto/sha1" // for crypto.SHA1
 )
@@ -49,9 +42,6 @@ var (
 	oidData                   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 1}
 	oidSignedData             = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}
 	oidEnvelopedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 3}
-	oidSignedAndEnvelopedData = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 4}
-	oidDigestedData           = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 5}
-	oidEncryptedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 6}
 	oidAttributeContentType   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
 	oidAttributeMessageDigest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
 	oidAttributeSigningTime   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
@@ -63,8 +53,13 @@ var (
 	oidDigestAlgorithmSHA512 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
 
 	// Signature Algorithms
-	oidEncryptionAlgorithmRSA       = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
-	oidEncryptionAlgorithmDSA       = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
+	oidEncryptionAlgorithmRSA     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	oidEncryptionAlgorithmDSA     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
+	oidDigestAlgorithmECDSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 1}
+	oidDigestAlgorithmECDSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	oidDigestAlgorithmECDSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
+	oidDigestAlgorithmECDSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
+
 	oidEncryptionAlgorithmECDSAP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
 	oidEncryptionAlgorithmECDSAP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
 	oidEncryptionAlgorithmECDSAP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
@@ -77,67 +72,56 @@ var (
 	oidEncryptionAlgorithmAES128CBC  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 2}
 )
 
-type signedData struct {
-	Version                    int                        `asn1:"default:1"`
-	DigestAlgorithmIdentifiers []pkix.AlgorithmIdentifier `asn1:"set"`
-	ContentInfo                contentInfo
-	Certificates               rawCertificates        `asn1:"optional,tag:0"`
-	CRLs                       []pkix.CertificateList `asn1:"optional,tag:1"`
-	SignerInfos                []signerInfo           `asn1:"set"`
+func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
+	switch {
+	case oid.Equal(oidDigestAlgorithmSHA1), oid.Equal(oidDigestAlgorithmECDSASHA1):
+		return crypto.SHA1, nil
+	case oid.Equal(oidDigestAlgorithmSHA256), oid.Equal(oidDigestAlgorithmECDSASHA256):
+		return crypto.SHA256, nil
+	case oid.Equal(oidDigestAlgorithmSHA384), oid.Equal(oidDigestAlgorithmECDSASHA384):
+		return crypto.SHA384, nil
+	case oid.Equal(oidDigestAlgorithmSHA512), oid.Equal(oidDigestAlgorithmECDSASHA512):
+		return crypto.SHA512, nil
+	}
+	return crypto.Hash(0), ErrUnsupportedAlgorithm
 }
 
-type rawCertificates struct {
-	Raw asn1.RawContent
+// getDigestOIDForSignatureAlgorithm takes an x509.SignatureAlgorithm
+// and returns the corresponding OID digest algorithm
+func getDigestOIDForSignatureAlgorithm(digestAlg x509.SignatureAlgorithm) (asn1.ObjectIdentifier, error) {
+	switch digestAlg {
+	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
+		return oidDigestAlgorithmSHA1, nil
+	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
+		return oidDigestAlgorithmSHA256, nil
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
+		return oidDigestAlgorithmSHA384, nil
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
+		return oidDigestAlgorithmSHA512, nil
+	}
+	return nil, fmt.Errorf("pkcs7: cannot convert hash to oid, unknown hash algorithm")
 }
 
-type envelopedData struct {
-	Version              int
-	RecipientInfos       []recipientInfo `asn1:"set"`
-	EncryptedContentInfo encryptedContentInfo
-}
+// getOIDForEncryptionAlgorithm takes the private key type of the signer and
+// the OID of a digest algorithm to return the appropriate signerInfo.DigestEncryptionAlgorithm
+func getOIDForEncryptionAlgorithm(key crypto.PrivateKey, oidDigestAlg asn1.ObjectIdentifier) (asn1.ObjectIdentifier, error) {
+	switch key.(type) {
+	case *rsa.PrivateKey:
+		return oidEncryptionAlgorithmRSA, nil
+	case *ecdsa.PrivateKey:
+		switch {
+		case oidDigestAlg.Equal(oidDigestAlgorithmSHA1):
+			return oidDigestAlgorithmECDSASHA1, nil
+		case oidDigestAlg.Equal(oidDigestAlgorithmSHA256):
+			return oidDigestAlgorithmECDSASHA256, nil
+		case oidDigestAlg.Equal(oidDigestAlgorithmSHA384):
+			return oidDigestAlgorithmECDSASHA384, nil
+		case oidDigestAlg.Equal(oidDigestAlgorithmSHA512):
+			return oidDigestAlgorithmECDSASHA512, nil
+		}
+	}
+	return nil, fmt.Errorf("pkcs7: cannot convert encryption algorithm to oid, unknown private key type %T", key)
 
-type recipientInfo struct {
-	Version                int
-	IssuerAndSerialNumber  issuerAndSerial
-	KeyEncryptionAlgorithm pkix.AlgorithmIdentifier
-	EncryptedKey           []byte
-}
-
-type encryptedContentInfo struct {
-	ContentType                asn1.ObjectIdentifier
-	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
-	EncryptedContent           asn1.RawValue `asn1:"tag:0,optional,explicit"`
-}
-
-type attribute struct {
-	Type  asn1.ObjectIdentifier
-	Value asn1.RawValue `asn1:"set"`
-}
-
-type issuerAndSerial struct {
-	IssuerName   asn1.RawValue
-	SerialNumber *big.Int
-}
-
-// MessageDigestMismatchError is returned when the signer data digest does not
-// match the computed digest for the contained content
-type MessageDigestMismatchError struct {
-	ExpectedDigest []byte
-	ActualDigest   []byte
-}
-
-func (err *MessageDigestMismatchError) Error() string {
-	return fmt.Sprintf("pkcs7: Message digest mismatch\n\tExpected: %X\n\tActual  : %X", err.ExpectedDigest, err.ActualDigest)
-}
-
-type signerInfo struct {
-	Version                   int `asn1:"default:1"`
-	IssuerAndSerialNumber     issuerAndSerial
-	DigestAlgorithm           pkix.AlgorithmIdentifier
-	AuthenticatedAttributes   []attribute `asn1:"optional,tag:0"`
-	DigestEncryptionAlgorithm pkix.AlgorithmIdentifier
-	EncryptedDigest           []byte
-	UnauthenticatedAttributes []attribute `asn1:"optional,tag:1"`
 }
 
 // Parse decodes a DER encoded PKCS7 package
@@ -169,39 +153,14 @@ func Parse(data []byte) (p7 *PKCS7, err error) {
 	return nil, ErrUnsupportedContentType
 }
 
-func parseSignedData(data []byte) (*PKCS7, error) {
-	var sd signedData
-	asn1.Unmarshal(data, &sd)
-	certs, err := sd.Certificates.Parse()
-	if err != nil {
+func parseEnvelopedData(data []byte) (*PKCS7, error) {
+	var ed envelopedData
+	if _, err := asn1.Unmarshal(data, &ed); err != nil {
 		return nil, err
 	}
-	// fmt.Printf("--> Signed Data Version %d\n", sd.Version)
-
-	var compound asn1.RawValue
-	var content unsignedData
-
-	// The Content.Bytes maybe empty on PKI responses.
-	if len(sd.ContentInfo.Content.Bytes) > 0 {
-		if _, err := asn1.Unmarshal(sd.ContentInfo.Content.Bytes, &compound); err != nil {
-			return nil, err
-		}
-	}
-	// Compound octet string
-	if compound.IsCompound {
-		if _, err = asn1.Unmarshal(compound.Bytes, &content); err != nil {
-			return nil, err
-		}
-	} else {
-		// assuming this is tag 04
-		content = compound.Bytes
-	}
 	return &PKCS7{
-		Content:      content,
-		Certificates: certs,
-		CRLs:         sd.CRLs,
-		Signers:      sd.SignerInfos,
-		raw:          sd}, nil
+		raw: ed,
+	}, nil
 }
 
 func (raw rawCertificates) Parse() ([]*x509.Certificate, error) {
@@ -217,402 +176,8 @@ func (raw rawCertificates) Parse() ([]*x509.Certificate, error) {
 	return x509.ParseCertificates(val.Bytes)
 }
 
-func parseEnvelopedData(data []byte) (*PKCS7, error) {
-	var ed envelopedData
-	if _, err := asn1.Unmarshal(data, &ed); err != nil {
-		return nil, err
-	}
-	return &PKCS7{
-		raw: ed,
-	}, nil
-}
-
-// Verify is a wrapper around VerifyWithChain() that initializes an empty
-// trust store, effectively disabling certificate verification when validating
-// a signature.
-func (p7 *PKCS7) Verify() (err error) {
-	return p7.VerifyWithChain(nil)
-}
-
-// VerifyWithChain checks the signatures of a PKCS7 object.
-// If truststore is not nil, it also verifies the chain of trust of the end-entity
-// signer cert to one of the root in the truststore.
-func (p7 *PKCS7) VerifyWithChain(truststore *x509.CertPool) (err error) {
-	if len(p7.Signers) == 0 {
-		return errors.New("pkcs7: Message has no signers")
-	}
-	for _, signer := range p7.Signers {
-		if err := verifySignature(p7, signer, truststore); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (err error) {
-	signedData := p7.Content
-	ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
-	if ee == nil {
-		return errors.New("pkcs7: No certificate for signer")
-	}
-	signingTime := time.Now().UTC()
-	if len(signer.AuthenticatedAttributes) > 0 {
-		// TODO(fullsailor): First check the content type match
-		var digest []byte
-		err := unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeMessageDigest, &digest)
-		if err != nil {
-			return err
-		}
-		hash, err := getHashForOID(signer.DigestAlgorithm.Algorithm)
-		if err != nil {
-			return err
-		}
-		h := hash.New()
-		h.Write(p7.Content)
-		computed := h.Sum(nil)
-		if subtle.ConstantTimeCompare(digest, computed) != 1 {
-			return &MessageDigestMismatchError{
-				ExpectedDigest: digest,
-				ActualDigest:   computed,
-			}
-		}
-		signedData, err = marshalAttributes(signer.AuthenticatedAttributes)
-		if err != nil {
-			return err
-		}
-		err = unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeSigningTime, &signingTime)
-		if err == nil {
-			// signing time found, performing validity check
-			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
-				return fmt.Errorf("pkcs7: signing time %q it outside of certificate validity %q to %q",
-					signingTime.Format(time.RFC3339),
-					ee.NotBefore.Format(time.RFC3339),
-					ee.NotBefore.Format(time.RFC3339))
-			}
-		}
-	}
-	if truststore != nil {
-		_, err = verifyCertChain(ee, p7.Certificates, truststore, signingTime)
-		if err != nil {
-			return err
-		}
-	}
-	sigalg, err := getSignatureAlgorithm(signer.DigestEncryptionAlgorithm, signer.DigestAlgorithm)
-	if err != nil {
-		return err
-	}
-	return ee.CheckSignature(sigalg, signedData, signer.EncryptedDigest)
-}
-
-func marshalAttributes(attrs []attribute) ([]byte, error) {
-	encodedAttributes, err := asn1.Marshal(struct {
-		A []attribute `asn1:"set"`
-	}{A: attrs})
-	if err != nil {
-		return nil, err
-	}
-
-	// Remove the leading sequence octets
-	var raw asn1.RawValue
-	asn1.Unmarshal(encodedAttributes, &raw)
-	return raw.Bytes, nil
-}
-
-func getSignatureAlgorithm(digestEncryption, digest pkix.AlgorithmIdentifier) (x509.SignatureAlgorithm, error) {
-	if digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSA) {
-		if digest.Algorithm.Equal(oidDigestAlgorithmSHA1) {
-			return x509.SHA1WithRSA, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA256) {
-			return x509.SHA256WithRSA, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA384) {
-			return x509.SHA384WithRSA, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA512) {
-			return x509.SHA512WithRSA, nil
-		}
-	} else if digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmDSA) {
-		if digest.Algorithm.Equal(oidDigestAlgorithmSHA1) {
-			return x509.DSAWithSHA1, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA256) {
-			return x509.DSAWithSHA256, nil
-		}
-	} else if digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP256) ||
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP384) ||
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP521) {
-		if digest.Algorithm.Equal(oidDigestAlgorithmSHA1) {
-			return x509.ECDSAWithSHA1, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA256) {
-			return x509.ECDSAWithSHA256, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA384) {
-			return x509.ECDSAWithSHA384, nil
-		} else if digest.Algorithm.Equal(oidDigestAlgorithmSHA512) {
-			return x509.ECDSAWithSHA512, nil
-		}
-	}
-	return -1, fmt.Errorf("pkcs7: unsupported digest encryption algorithm")
-}
-
-func getCertFromCertsByIssuerAndSerial(certs []*x509.Certificate, ias issuerAndSerial) *x509.Certificate {
-	for _, cert := range certs {
-		if isCertMatchForIssuerAndSerial(cert, ias) {
-			return cert
-		}
-	}
-	return nil
-}
-
-func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
-	switch {
-	case oid.Equal(oidDigestAlgorithmSHA1):
-		return crypto.SHA1, nil
-	case oid.Equal(oidDigestAlgorithmSHA256):
-		return crypto.SHA256, nil
-	case oid.Equal(oidDigestAlgorithmSHA384):
-		return crypto.SHA384, nil
-	case oid.Equal(oidDigestAlgorithmSHA512):
-		return crypto.SHA512, nil
-	}
-	return crypto.Hash(0), ErrUnsupportedAlgorithm
-}
-
-func getOIDForHash(digestAlg crypto.Hash) (asn1.ObjectIdentifier, error) {
-	switch digestAlg {
-	case crypto.SHA1:
-		return oidDigestAlgorithmSHA1, nil
-	case crypto.SHA256:
-		return oidDigestAlgorithmSHA256, nil
-	case crypto.SHA384:
-		return oidDigestAlgorithmSHA384, nil
-	case crypto.SHA512:
-		return oidDigestAlgorithmSHA512, nil
-	default:
-		return nil, fmt.Errorf("pkcs7: cannot convert hash to oid, unknown hash algorithm")
-	}
-}
-
-func getOIDForEncryptionAlgorithm(key crypto.PrivateKey) (asn1.ObjectIdentifier, error) {
-	switch key.(type) {
-	case *rsa.PrivateKey:
-		return oidEncryptionAlgorithmRSA, nil
-	case *ecdsa.PrivateKey:
-		switch key.(*ecdsa.PrivateKey).Curve.Params().Name {
-		case "P-256":
-			return oidEncryptionAlgorithmECDSAP256, nil
-		case "P-384":
-			return oidEncryptionAlgorithmECDSAP384, nil
-		case "P-521":
-			return oidEncryptionAlgorithmECDSAP521, nil
-		}
-	}
-	return nil, fmt.Errorf("pkcs7: cannot convert encryption algorithm to oid, unknown private key type %T", key)
-
-}
-
-// GetOnlySigner returns an x509.Certificate for the first signer of the signed
-// data payload. If there are more or less than one signer, nil is returned
-func (p7 *PKCS7) GetOnlySigner() *x509.Certificate {
-	if len(p7.Signers) != 1 {
-		return nil
-	}
-	signer := p7.Signers[0]
-	return getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
-}
-
-// ErrUnsupportedAlgorithm tells you when our quick dev assumptions have failed
-var ErrUnsupportedAlgorithm = errors.New("pkcs7: cannot decrypt data: only RSA, DES, DES-EDE3, AES-256-CBC and AES-128-GCM supported")
-
-// ErrNotEncryptedContent is returned when attempting to Decrypt data that is not encrypted data
-var ErrNotEncryptedContent = errors.New("pkcs7: content data is a decryptable data type")
-
-// Decrypt decrypts encrypted content info for recipient cert and private key
-func (p7 *PKCS7) Decrypt(cert *x509.Certificate, pkey crypto.PrivateKey) ([]byte, error) {
-	data, ok := p7.raw.(envelopedData)
-	if !ok {
-		return nil, ErrNotEncryptedContent
-	}
-	recipient := selectRecipientForCertificate(data.RecipientInfos, cert)
-	if recipient.EncryptedKey == nil {
-		return nil, errors.New("pkcs7: no enveloped recipient for provided certificate")
-	}
-	switch pkey.(type) {
-	case *rsa.PrivateKey:
-		var contentKey []byte
-		contentKey, err := rsa.DecryptPKCS1v15(rand.Reader, pkey.(*rsa.PrivateKey), recipient.EncryptedKey)
-		if err != nil {
-			return nil, err
-		}
-		return data.EncryptedContentInfo.decrypt(contentKey)
-	}
-	return nil, ErrUnsupportedAlgorithm
-}
-
-func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
-	alg := eci.ContentEncryptionAlgorithm.Algorithm
-	if !alg.Equal(oidEncryptionAlgorithmDESCBC) &&
-		!alg.Equal(oidEncryptionAlgorithmDESEDE3CBC) &&
-		!alg.Equal(oidEncryptionAlgorithmAES256CBC) &&
-		!alg.Equal(oidEncryptionAlgorithmAES128CBC) &&
-		!alg.Equal(oidEncryptionAlgorithmAES128GCM) {
-		fmt.Printf("Unsupported Content Encryption Algorithm: %s\n", alg)
-		return nil, ErrUnsupportedAlgorithm
-	}
-
-	// EncryptedContent can either be constructed of multple OCTET STRINGs
-	// or _be_ a tagged OCTET STRING
-	var cyphertext []byte
-	if eci.EncryptedContent.IsCompound {
-		// Complex case to concat all of the children OCTET STRINGs
-		var buf bytes.Buffer
-		cypherbytes := eci.EncryptedContent.Bytes
-		for {
-			var part []byte
-			cypherbytes, _ = asn1.Unmarshal(cypherbytes, &part)
-			buf.Write(part)
-			if cypherbytes == nil {
-				break
-			}
-		}
-		cyphertext = buf.Bytes()
-	} else {
-		// Simple case, the bytes _are_ the cyphertext
-		cyphertext = eci.EncryptedContent.Bytes
-	}
-
-	var block cipher.Block
-	var err error
-
-	switch {
-	case alg.Equal(oidEncryptionAlgorithmDESCBC):
-		block, err = des.NewCipher(key)
-	case alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
-		block, err = des.NewTripleDESCipher(key)
-	case alg.Equal(oidEncryptionAlgorithmAES256CBC):
-		fallthrough
-	case alg.Equal(oidEncryptionAlgorithmAES128GCM), alg.Equal(oidEncryptionAlgorithmAES128CBC):
-		block, err = aes.NewCipher(key)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if alg.Equal(oidEncryptionAlgorithmAES128GCM) {
-		params := aesGCMParameters{}
-		paramBytes := eci.ContentEncryptionAlgorithm.Parameters.Bytes
-
-		_, err := asn1.Unmarshal(paramBytes, &params)
-		if err != nil {
-			return nil, err
-		}
-
-		gcm, err := cipher.NewGCM(block)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(params.Nonce) != gcm.NonceSize() {
-			return nil, errors.New("pkcs7: encryption algorithm parameters are incorrect")
-		}
-		if params.ICVLen != gcm.Overhead() {
-			return nil, errors.New("pkcs7: encryption algorithm parameters are incorrect")
-		}
-
-		plaintext, err := gcm.Open(nil, params.Nonce, cyphertext, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		return plaintext, nil
-	}
-
-	iv := eci.ContentEncryptionAlgorithm.Parameters.Bytes
-	if len(iv) != block.BlockSize() {
-		return nil, errors.New("pkcs7: encryption algorithm parameters are malformed")
-	}
-	mode := cipher.NewCBCDecrypter(block, iv)
-	plaintext := make([]byte, len(cyphertext))
-	mode.CryptBlocks(plaintext, cyphertext)
-	if plaintext, err = unpad(plaintext, mode.BlockSize()); err != nil {
-		return nil, err
-	}
-	return plaintext, nil
-}
-
-func selectRecipientForCertificate(recipients []recipientInfo, cert *x509.Certificate) recipientInfo {
-	for _, recp := range recipients {
-		if isCertMatchForIssuerAndSerial(cert, recp.IssuerAndSerialNumber) {
-			return recp
-		}
-	}
-	return recipientInfo{}
-}
-
 func isCertMatchForIssuerAndSerial(cert *x509.Certificate, ias issuerAndSerial) bool {
-	return cert.SerialNumber.Cmp(ias.SerialNumber) == 0 && bytes.Compare(cert.RawIssuer, ias.IssuerName.FullBytes) == 0
-}
-
-func pad(data []byte, blocklen int) ([]byte, error) {
-	if blocklen < 1 {
-		return nil, fmt.Errorf("invalid blocklen %d", blocklen)
-	}
-	padlen := blocklen - (len(data) % blocklen)
-	if padlen == 0 {
-		padlen = blocklen
-	}
-	pad := bytes.Repeat([]byte{byte(padlen)}, padlen)
-	return append(data, pad...), nil
-}
-
-func unpad(data []byte, blocklen int) ([]byte, error) {
-	if blocklen < 1 {
-		return nil, fmt.Errorf("invalid blocklen %d", blocklen)
-	}
-	if len(data)%blocklen != 0 || len(data) == 0 {
-		return nil, fmt.Errorf("invalid data len %d", len(data))
-	}
-
-	// the last byte is the length of padding
-	padlen := int(data[len(data)-1])
-
-	// check padding integrity, all bytes should be the same
-	pad := data[len(data)-padlen:]
-	for _, padbyte := range pad {
-		if padbyte != byte(padlen) {
-			return nil, errors.New("invalid padding")
-		}
-	}
-
-	return data[:len(data)-padlen], nil
-}
-
-func unmarshalAttribute(attrs []attribute, attributeType asn1.ObjectIdentifier, out interface{}) error {
-	for _, attr := range attrs {
-		if attr.Type.Equal(attributeType) {
-			_, err := asn1.Unmarshal(attr.Value.Bytes, out)
-			return err
-		}
-	}
-	return errors.New("pkcs7: attribute type not in attributes")
-}
-
-// UnmarshalSignedAttribute decodes a single attribute from the signer info
-func (p7 *PKCS7) UnmarshalSignedAttribute(attributeType asn1.ObjectIdentifier, out interface{}) error {
-	sd, ok := p7.raw.(signedData)
-	if !ok {
-		return errors.New("pkcs7: payload is not signedData content")
-	}
-	if len(sd.SignerInfos) < 1 {
-		return errors.New("pkcs7: payload has no signers")
-	}
-	attributes := sd.SignerInfos[0].AuthenticatedAttributes
-	return unmarshalAttribute(attributes, attributeType, out)
-}
-
-// SignedData is an opaque data structure for creating signed data payloads
-type SignedData struct {
-	sd            signedData
-	certs         []*x509.Certificate
-	digestAlg     crypto.Hash
-	messageDigest []byte
+	return cert.SerialNumber.Cmp(ias.SerialNumber) == 0 && bytes.Equal(cert.RawIssuer, ias.IssuerName.FullBytes)
 }
 
 // Attribute represents a key value pair attribute. Value must be marshalable byte
@@ -620,47 +185,6 @@ type SignedData struct {
 type Attribute struct {
 	Type  asn1.ObjectIdentifier
 	Value interface{}
-}
-
-// SignerInfoConfig are optional values to include when adding a signer
-type SignerInfoConfig struct {
-	ExtraSignedAttributes []Attribute
-}
-
-// NewSignedData is a wrapper around new NewSignedDataWithHash() that initializes
-// a signed data struct using the SHA1 hashing algorithm.
-func NewSignedData(data []byte) (*SignedData, error) {
-	return NewSignedDataWithHash(data, crypto.SHA1)
-}
-
-// NewSignedDataWithHash takes data and a hash algorithm and initializes a PKCS7 SignedData
-// struct that is ready to be signed via AddSigner. The hash algorithm is a crypto.Hash
-// constant of a SHA1/256/384/512 function (eg. `crypto.SHA256`).
-func NewSignedDataWithHash(data []byte, digestAlg crypto.Hash) (*SignedData, error) {
-	content, err := asn1.Marshal(data)
-	if err != nil {
-		return nil, err
-	}
-	ci := contentInfo{
-		ContentType: oidData,
-		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
-	}
-	oid, err := getOIDForHash(digestAlg)
-	if err != nil {
-		return nil, err
-	}
-	digAlg := pkix.AlgorithmIdentifier{
-		Algorithm: oid,
-	}
-	h := digestAlg.New()
-	h.Write(data)
-	md := h.Sum(nil)
-	sd := signedData{
-		ContentInfo:                ci,
-		Version:                    1,
-		DigestAlgorithmIdentifiers: []pkix.AlgorithmIdentifier{digAlg},
-	}
-	return &SignedData{sd: sd, messageDigest: md, digestAlg: digestAlg}, nil
 }
 
 type attributes struct {
@@ -725,422 +249,4 @@ func (attrs *attributes) ForMarshalling() ([]attribute, error) {
 	}
 	sort.Sort(sortables)
 	return sortables.Attributes(), nil
-}
-
-// AddSigner is a wrapper around AddSignerWithParents() that adds a signer without any parent.
-func (sd *SignedData) AddSigner(ee *x509.Certificate, pkey crypto.PrivateKey, config SignerInfoConfig) error {
-	var parents []*x509.Certificate
-	return sd.AddSignerWithParents(ee, pkey, parents, config)
-}
-
-// AddSignerWithParents signs attributes about the content and adds certificates
-// and signers infos to the Signed Data. The certificate and private
-// of the end-entity signer are used to issue the signature, and any
-// parent of that end-entity that need to be added to the list of
-// certifications can be specified in the parents slice.
-//
-// Following RFC 2315, 9.2 SignerInfo type, the distinguished name of
-// the issuer of the end-entity signer is stored in the issuerAndSerialNumber
-// section of the SignedData.SignerInfo, alongside the serial number of
-// the end-entity.
-func (sd *SignedData) AddSignerWithParents(ee *x509.Certificate, pkey crypto.PrivateKey, parents []*x509.Certificate, config SignerInfoConfig) error {
-	attrs := &attributes{}
-	attrs.Add(oidAttributeContentType, sd.sd.ContentInfo.ContentType)
-	attrs.Add(oidAttributeMessageDigest, sd.messageDigest)
-	attrs.Add(oidAttributeSigningTime, time.Now())
-	for _, attr := range config.ExtraSignedAttributes {
-		attrs.Add(attr.Type, attr.Value)
-	}
-	finalAttrs, err := attrs.ForMarshalling()
-	if err != nil {
-		return err
-	}
-	signature, err := signAttributes(finalAttrs, pkey, sd.digestAlg)
-	if err != nil {
-		return err
-	}
-	var ias issuerAndSerial
-	ias.SerialNumber = ee.SerialNumber
-	if len(parents) == 0 {
-		// no parent, the issue is the end-entity cert itself
-		ias.IssuerName = asn1.RawValue{FullBytes: ee.RawIssuer}
-	} else {
-		err = verifyPartialChain(ee, parents)
-		if err != nil {
-			return err
-		}
-		// the first parent is the issuer
-		ias.IssuerName = asn1.RawValue{FullBytes: parents[0].RawSubject}
-	}
-	oidDigestAlg, err := getOIDForHash(sd.digestAlg)
-	if err != nil {
-		return err
-	}
-	oidEncryptionAlg, err := getOIDForEncryptionAlgorithm(pkey)
-	if err != nil {
-		return err
-	}
-	signer := signerInfo{
-		AuthenticatedAttributes:   finalAttrs,
-		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: oidDigestAlg},
-		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: oidEncryptionAlg},
-		IssuerAndSerialNumber:     ias,
-		EncryptedDigest:           signature,
-		Version:                   1,
-	}
-	// create signature of signed attributes
-	sd.certs = append(sd.certs, ee)
-	sd.certs = append(sd.certs, parents...)
-	sd.sd.SignerInfos = append(sd.sd.SignerInfos, signer)
-	return nil
-}
-
-// AddCertificate adds the certificate to the payload. Useful for parent certificates
-func (sd *SignedData) AddCertificate(cert *x509.Certificate) {
-	sd.certs = append(sd.certs, cert)
-}
-
-// Detach removes content from the signed data struct to make it a detached signature.
-// This must be called right before Finish()
-func (sd *SignedData) Detach() {
-	sd.sd.ContentInfo = contentInfo{ContentType: oidSignedData}
-}
-
-// Finish marshals the content and its signers
-func (sd *SignedData) Finish() ([]byte, error) {
-	sd.sd.Certificates = marshalCertificates(sd.certs)
-	inner, err := asn1.Marshal(sd.sd)
-	if err != nil {
-		return nil, err
-	}
-	outer := contentInfo{
-		ContentType: oidSignedData,
-		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: inner, IsCompound: true},
-	}
-	return asn1.Marshal(outer)
-}
-
-// verifyCertChain takes an end-entity certs, a list of potential intermediates and a
-// truststore, and built all potential chains between the EE and a trusted root.
-//
-// When verifying chains that may have expired, currentTime can be set to a past date
-// to allow the verification to pass. If unset, currentTime is set to the current UTC time.
-func verifyCertChain(ee *x509.Certificate, certs []*x509.Certificate, truststore *x509.CertPool, currentTime time.Time) (chains [][]*x509.Certificate, err error) {
-	intermediates := x509.NewCertPool()
-	for _, intermediate := range certs {
-		intermediates.AddCert(intermediate)
-	}
-	verifyOptions := x509.VerifyOptions{
-		Roots:         truststore,
-		Intermediates: intermediates,
-		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
-		CurrentTime:   currentTime,
-	}
-	chains, err = ee.Verify(verifyOptions)
-	if err != nil {
-		return chains, fmt.Errorf("pkcs7: failed to verify certificate chain: %v", err)
-	}
-	return
-}
-
-// verifyPartialChain checks that a given cert is issued by the first parent in the list,
-// then continue down the path. It doesn't require the last parent to be a root CA,
-// or to be trusted in any truststore. It simply verifies that the chain provided, albeit
-// partial, makes sense.
-func verifyPartialChain(cert *x509.Certificate, parents []*x509.Certificate) error {
-	if len(parents) == 0 {
-		return fmt.Errorf("pkcs7: zero parents provided to verify the signature of certificate %q", cert.Subject.CommonName)
-	}
-	err := cert.CheckSignatureFrom(parents[0])
-	if err != nil {
-		return fmt.Errorf("pkcs7: certificate signature from parent is invalid: %v", err)
-	}
-	if len(parents) == 1 {
-		// there is no more parent to check, return
-		return nil
-	}
-	return verifyPartialChain(parents[0], parents[1:])
-}
-
-func cert2issuerAndSerial(cert *x509.Certificate) (issuerAndSerial, error) {
-	var ias issuerAndSerial
-	// The issuer RDNSequence has to match exactly the sequence in the certificate
-	// We cannot use cert.Issuer.ToRDNSequence() here since it mangles the sequence
-	ias.IssuerName = asn1.RawValue{FullBytes: cert.RawIssuer}
-	ias.SerialNumber = cert.SerialNumber
-
-	return ias, nil
-}
-
-type ecdsaSignature struct {
-	R, S *big.Int // fields must be exported for ASN.1 marshalling
-}
-
-// signs the DER encoded form of the attributes with the private key
-func signAttributes(attrs []attribute, pkey crypto.PrivateKey, digestAlg crypto.Hash) ([]byte, error) {
-	attrBytes, err := marshalAttributes(attrs)
-	if err != nil {
-		return nil, err
-	}
-	h := digestAlg.New()
-	h.Write(attrBytes)
-	hash := h.Sum(nil)
-	switch pkey.(type) {
-	case *rsa.PrivateKey:
-		return rsa.SignPKCS1v15(rand.Reader, pkey.(*rsa.PrivateKey), digestAlg, hash)
-	case *ecdsa.PrivateKey:
-		r, s, err := ecdsa.Sign(rand.Reader, pkey.(*ecdsa.PrivateKey), hash)
-		if err != nil {
-			return nil, fmt.Errorf("pkcs7: failed to sign attributes: %v", err)
-		}
-		return asn1.Marshal(ecdsaSignature{R: r, S: s})
-	}
-	return nil, fmt.Errorf("pkcs7: unsupported signing key type %T", pkey)
-}
-
-// concats and wraps the certificates in the RawValue structure
-func marshalCertificates(certs []*x509.Certificate) rawCertificates {
-	var buf bytes.Buffer
-	for _, cert := range certs {
-		buf.Write(cert.Raw)
-	}
-	rawCerts, _ := marshalCertificateBytes(buf.Bytes())
-	return rawCerts
-}
-
-// Even though, the tag & length are stripped out during marshalling the
-// RawContent, we have to encode it into the RawContent. If its missing,
-// then `asn1.Marshal()` will strip out the certificate wrapper instead.
-func marshalCertificateBytes(certs []byte) (rawCertificates, error) {
-	var val = asn1.RawValue{Bytes: certs, Class: 2, Tag: 0, IsCompound: true}
-	b, err := asn1.Marshal(val)
-	if err != nil {
-		return rawCertificates{}, err
-	}
-	return rawCertificates{Raw: b}, nil
-}
-
-// DegenerateCertificate creates a signed data structure containing only the
-// provided certificate or certificate chain.
-func DegenerateCertificate(cert []byte) ([]byte, error) {
-	rawCert, err := marshalCertificateBytes(cert)
-	if err != nil {
-		return nil, err
-	}
-	emptyContent := contentInfo{ContentType: oidData}
-	sd := signedData{
-		Version:      1,
-		ContentInfo:  emptyContent,
-		Certificates: rawCert,
-		CRLs:         []pkix.CertificateList{},
-	}
-	content, err := asn1.Marshal(sd)
-	if err != nil {
-		return nil, err
-	}
-	signedContent := contentInfo{
-		ContentType: oidSignedData,
-		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
-	}
-	return asn1.Marshal(signedContent)
-}
-
-const (
-	// EncryptionAlgorithmDESCBC is the DES CBC encryption algorithm
-	EncryptionAlgorithmDESCBC = iota
-
-	// EncryptionAlgorithmAES128GCM is the AES 128 bits with GCM encryption algorithm
-	EncryptionAlgorithmAES128GCM
-)
-
-// ContentEncryptionAlgorithm determines the algorithm used to encrypt the
-// plaintext message. Change the value of this variable to change which
-// algorithm is used in the Encrypt() function.
-var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
-
-// ErrUnsupportedEncryptionAlgorithm is returned when attempting to encrypt
-// content with an unsupported algorithm.
-var ErrUnsupportedEncryptionAlgorithm = errors.New("pkcs7: cannot encrypt content: only DES-CBC and AES-128-GCM supported")
-
-const nonceSize = 12
-
-type aesGCMParameters struct {
-	Nonce  []byte `asn1:"tag:4"`
-	ICVLen int
-}
-
-func encryptAES128GCM(content []byte) ([]byte, *encryptedContentInfo, error) {
-	// Create AES key and nonce
-	key := make([]byte, 16)
-	nonce := make([]byte, nonceSize)
-
-	_, err := rand.Read(key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	_, err = rand.Read(nonce)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encrypt content
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ciphertext := gcm.Seal(nil, nonce, content, nil)
-
-	// Prepare ASN.1 Encrypted Content Info
-	paramSeq := aesGCMParameters{
-		Nonce:  nonce,
-		ICVLen: gcm.Overhead(),
-	}
-
-	paramBytes, err := asn1.Marshal(paramSeq)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	eci := encryptedContentInfo{
-		ContentType: oidData,
-		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
-			Algorithm: oidEncryptionAlgorithmAES128GCM,
-			Parameters: asn1.RawValue{
-				Tag:   asn1.TagSequence,
-				Bytes: paramBytes,
-			},
-		},
-		EncryptedContent: marshalEncryptedContent(ciphertext),
-	}
-
-	return key, &eci, nil
-}
-
-func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
-	// Create DES key & CBC IV
-	key := make([]byte, 8)
-	iv := make([]byte, des.BlockSize)
-	_, err := rand.Read(key)
-	if err != nil {
-		return nil, nil, err
-	}
-	_, err = rand.Read(iv)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encrypt padded content
-	block, err := des.NewCipher(key)
-	if err != nil {
-		return nil, nil, err
-	}
-	mode := cipher.NewCBCEncrypter(block, iv)
-	plaintext, err := pad(content, mode.BlockSize())
-	cyphertext := make([]byte, len(plaintext))
-	mode.CryptBlocks(cyphertext, plaintext)
-
-	// Prepare ASN.1 Encrypted Content Info
-	eci := encryptedContentInfo{
-		ContentType: oidData,
-		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
-			Algorithm:  oidEncryptionAlgorithmDESCBC,
-			Parameters: asn1.RawValue{Tag: 4, Bytes: iv},
-		},
-		EncryptedContent: marshalEncryptedContent(cyphertext),
-	}
-
-	return key, &eci, nil
-}
-
-// Encrypt creates and returns an envelope data PKCS7 structure with encrypted
-// recipient keys for each recipient public key.
-//
-// The algorithm used to perform encryption is determined by the current value
-// of the global ContentEncryptionAlgorithm package variable. By default, the
-// value is EncryptionAlgorithmDESCBC. To use a different algorithm, change the
-// value before calling Encrypt(). For example:
-//
-//     ContentEncryptionAlgorithm = EncryptionAlgorithmAES128GCM
-//
-// TODO(fullsailor): Add support for encrypting content with other algorithms
-func Encrypt(content []byte, recipients []*x509.Certificate) ([]byte, error) {
-	var eci *encryptedContentInfo
-	var key []byte
-	var err error
-
-	// Apply chosen symmetric encryption method
-	switch ContentEncryptionAlgorithm {
-	case EncryptionAlgorithmDESCBC:
-		key, eci, err = encryptDESCBC(content)
-
-	case EncryptionAlgorithmAES128GCM:
-		key, eci, err = encryptAES128GCM(content)
-
-	default:
-		return nil, ErrUnsupportedEncryptionAlgorithm
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare each recipient's encrypted cipher key
-	recipientInfos := make([]recipientInfo, len(recipients))
-	for i, recipient := range recipients {
-		encrypted, err := encryptKey(key, recipient)
-		if err != nil {
-			return nil, err
-		}
-		ias, err := cert2issuerAndSerial(recipient)
-		if err != nil {
-			return nil, err
-		}
-		info := recipientInfo{
-			Version:               0,
-			IssuerAndSerialNumber: ias,
-			KeyEncryptionAlgorithm: pkix.AlgorithmIdentifier{
-				Algorithm: oidEncryptionAlgorithmRSA,
-			},
-			EncryptedKey: encrypted,
-		}
-		recipientInfos[i] = info
-	}
-
-	// Prepare envelope content
-	envelope := envelopedData{
-		EncryptedContentInfo: *eci,
-		Version:              0,
-		RecipientInfos:       recipientInfos,
-	}
-	innerContent, err := asn1.Marshal(envelope)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare outer payload structure
-	wrapper := contentInfo{
-		ContentType: oidEnvelopedData,
-		Content:     asn1.RawValue{Class: 2, Tag: 0, IsCompound: true, Bytes: innerContent},
-	}
-
-	return asn1.Marshal(wrapper)
-}
-
-func marshalEncryptedContent(content []byte) asn1.RawValue {
-	asn1Content, _ := asn1.Marshal(content)
-	return asn1.RawValue{Tag: 0, Class: 2, Bytes: asn1Content, IsCompound: true}
-}
-
-func encryptKey(key []byte, recipient *x509.Certificate) ([]byte, error) {
-	if pub := recipient.PublicKey.(*rsa.PublicKey); pub != nil {
-		return rsa.EncryptPKCS1v15(rand.Reader, pub, key)
-	}
-	return nil, ErrUnsupportedAlgorithm
 }

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -1,7 +1,6 @@
 package pkcs7
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -9,421 +8,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
-	"os/exec"
-	"testing"
 	"time"
 )
-
-func TestVerify(t *testing.T) {
-	fixture := UnmarshalTestFixture(SignedTestFixture)
-	p7, err := Parse(fixture.Input)
-	if err != nil {
-		t.Errorf("Parse encountered unexpected error: %v", err)
-	}
-
-	if err := p7.Verify(); err != nil {
-		t.Errorf("Verify failed with error: %v", err)
-	}
-	expected := []byte("We the People")
-	if bytes.Compare(p7.Content, expected) != 0 {
-		t.Errorf("Signed content does not match.\n\tExpected:%s\n\tActual:%s", expected, p7.Content)
-
-	}
-}
-
-func TestVerifyEC2(t *testing.T) {
-	fixture := UnmarshalTestFixture(EC2IdentityDocumentFixture)
-	p7, err := Parse(fixture.Input)
-	if err != nil {
-		t.Errorf("Parse encountered unexpected error: %v", err)
-	}
-	p7.Certificates = []*x509.Certificate{fixture.Certificate}
-	if err := p7.Verify(); err != nil {
-		t.Errorf("Verify failed with error: %v", err)
-	}
-}
-
-func TestVerifyAppStore(t *testing.T) {
-	fixture := UnmarshalTestFixture(AppStoreReceiptFixture)
-	p7, err := Parse(fixture.Input)
-	if err != nil {
-		t.Errorf("Parse encountered unexpected error: %v", err)
-	}
-	if err := p7.Verify(); err != nil {
-		t.Errorf("Verify failed with error: %v", err)
-	}
-}
-
-func TestVerifyFirefoxAddon(t *testing.T) {
-	fixture := UnmarshalTestFixture(FirefoxAddonFixture)
-	p7, err := Parse(fixture.Input)
-	if err != nil {
-		t.Errorf("Parse encountered unexpected error: %v", err)
-	}
-	p7.Content = FirefoxAddonContent
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(FirefoxAddonRootCert)
-	if err := p7.VerifyWithChain(certPool); err != nil {
-		t.Errorf("Verify failed with error: %v", err)
-	}
-	// Verify the certificate chain to make sure the identified root
-	// is the one we expect
-	ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, p7.Signers[0].IssuerAndSerialNumber)
-	if ee == nil {
-		t.Errorf("No end-entity certificate found for signer")
-	}
-	signingTime, _ := time.Parse(time.RFC3339, "2017-02-23 09:06:16-05:00")
-	chains, err := verifyCertChain(ee, p7.Certificates, certPool, signingTime)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(chains) != 1 {
-		t.Errorf("Expected to find one chain, but found %d", len(chains))
-	}
-	if len(chains[0]) != 3 {
-		t.Errorf("Expected to find three certificates in chain, but found %d", len(chains[0]))
-	}
-	if chains[0][0].Subject.CommonName != "tabscope@xuldev.org" {
-		t.Errorf("Expected to find EE certificate with subject 'tabscope@xuldev.org', but found '%s'", chains[0][0].Subject.CommonName)
-	}
-	if chains[0][1].Subject.CommonName != "production-signing-ca.addons.mozilla.org" {
-		t.Errorf("Expected to find EE certificate with subject 'production-signing-ca.addons.mozilla.org', but found '%s'", chains[0][1].Subject.CommonName)
-	}
-	if chains[0][2].Subject.CommonName != "root-ca-production-amo" {
-		t.Errorf("Expected to find EE certificate with subject 'root-ca-production-amo', but found '%s'", chains[0][2].Subject.CommonName)
-	}
-}
-
-func TestDecrypt(t *testing.T) {
-	fixture := UnmarshalTestFixture(EncryptedTestFixture)
-	p7, err := Parse(fixture.Input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	content, err := p7.Decrypt(fixture.Certificate, fixture.PrivateKey)
-	if err != nil {
-		t.Errorf("Cannot Decrypt with error: %v", err)
-	}
-	expected := []byte("This is a test")
-	if bytes.Compare(content, expected) != 0 {
-		t.Errorf("Decrypted result does not match.\n\tExpected:%s\n\tActual:%s", expected, content)
-	}
-}
-
-func TestDegenerateCertificate(t *testing.T) {
-	cert, err := createTestCertificate(x509.SHA1WithRSA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	deg, err := DegenerateCertificate(cert.Certificate.Raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testOpenSSLParse(t, deg)
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: deg})
-}
-
-// writes the cert to a temporary file and tests that openssl can read it.
-func testOpenSSLParse(t *testing.T, certBytes []byte) {
-	tmpCertFile, err := ioutil.TempFile("", "testCertificate")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpCertFile.Name()) // clean up
-
-	if _, err := tmpCertFile.Write(certBytes); err != nil {
-		t.Fatal(err)
-	}
-
-	opensslCMD := exec.Command("openssl", "pkcs7", "-inform", "der", "-in", tmpCertFile.Name())
-	_, err = opensslCMD.Output()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := tmpCertFile.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-}
-
-func TestSign(t *testing.T) {
-	content := []byte("Hello World")
-	sigalgs := []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
-		x509.SHA256WithRSA,
-		x509.SHA512WithRSA,
-		x509.ECDSAWithSHA1,
-		x509.ECDSAWithSHA256,
-		x509.ECDSAWithSHA384,
-		x509.ECDSAWithSHA512,
-	}
-	for _, sigalgroot := range sigalgs {
-		rootCert, err := createTestCertificateByIssuer("PKCS7 Test Root CA", nil, sigalgroot, true)
-		if err != nil {
-			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
-		}
-		truststore := x509.NewCertPool()
-		truststore.AddCert(rootCert.Certificate)
-		for _, sigalginter := range sigalgs {
-			interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate Cert", rootCert, sigalginter, true)
-			if err != nil {
-				t.Fatalf("test %s/%s: cannot generate intermediate cert: %s", sigalgroot, sigalginter, err)
-			}
-			var parents []*x509.Certificate
-			parents = append(parents, interCert.Certificate)
-			for _, sigalgsigner := range sigalgs {
-				signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", interCert, sigalgsigner, false)
-				if err != nil {
-					t.Fatalf("test %s/%s/%s: cannot generate signer cert: %s", sigalgroot, sigalginter, sigalgsigner, err)
-				}
-				for _, testDetach := range []bool{false, true} {
-					log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalginter, sigalgsigner, testDetach)
-					toBeSigned, err := NewSignedData(content)
-					if err != nil {
-						t.Fatalf("test %s/%s/%s: cannot initialize signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
-					}
-					if err := toBeSigned.AddSignerWithParents(signerCert.Certificate, *signerCert.PrivateKey, parents, SignerInfoConfig{}); err != nil {
-						t.Fatalf("test %s/%s/%s: cannot add signer: %s", sigalgroot, sigalginter, sigalgsigner, err)
-					}
-					if testDetach {
-						toBeSigned.Detach()
-					}
-					signed, err := toBeSigned.Finish()
-					if err != nil {
-						t.Fatalf("test %s/%s/%s: cannot finish signing data: %s", sigalgroot, sigalginter, sigalgsigner, err)
-					}
-					pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
-					p7, err := Parse(signed)
-					if err != nil {
-						t.Fatalf("test %s/%s/%s: cannot parse signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
-					}
-					if testDetach {
-						p7.Content = content
-					}
-					if bytes.Compare(content, p7.Content) != 0 {
-						t.Errorf("test %s/%s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalginter, sigalgsigner, content, p7.Content)
-					}
-					if err := p7.VerifyWithChain(truststore); err != nil {
-						t.Errorf("test %s/%s/%s: cannot verify signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
-					}
-				}
-			}
-		}
-	}
-}
-
-func ExampleSignedData() {
-	// generate a signing cert or load a key pair
-	cert, err := createTestCertificate(x509.SHA256WithRSA)
-	if err != nil {
-		fmt.Printf("Cannot create test certificates: %s", err)
-	}
-
-	// Initialize a SignedData struct with content to be signed
-	signedData, err := NewSignedData([]byte("Example data to be signed"))
-	if err != nil {
-		fmt.Printf("Cannot initialize signed data: %s", err)
-	}
-
-	// Add the signing cert and private key
-	if err := signedData.AddSigner(cert.Certificate, cert.PrivateKey, SignerInfoConfig{}); err != nil {
-		fmt.Printf("Cannot add signer: %s", err)
-	}
-
-	// Call Detach() is you want to remove content from the signature
-	// and generate an S/MIME detached signature
-	signedData.Detach()
-
-	// Finish() to obtain the signature bytes
-	detachedSignature, err := signedData.Finish()
-	if err != nil {
-		fmt.Printf("Cannot finish signing data: %s", err)
-	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
-}
-
-func TestOpenSSLVerifyDetachedSignature(t *testing.T) {
-	content := []byte("Hello World")
-	sigalgs := []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
-		x509.SHA256WithRSA,
-		x509.SHA512WithRSA,
-		x509.ECDSAWithSHA1,
-		x509.ECDSAWithSHA256,
-		x509.ECDSAWithSHA384,
-		x509.ECDSAWithSHA512,
-	}
-	for i, sigalg := range sigalgs {
-		log.Printf("test case %d sigalg %s\n", i, sigalg)
-		rootCert, err := createTestCertificateByIssuer("PKCS7 Test Root CA", nil, sigalg, true)
-		if err != nil {
-			t.Fatalf("test case %d sigalg %s: cannot generate root cert: %s", i, sigalg, err)
-		}
-		interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate CA", rootCert, sigalg, true)
-		if err != nil {
-			t.Fatalf("test case %d sigalg %s: cannot generate intermediate cert: %s", i, sigalg, err)
-		}
-		var parents []*x509.Certificate
-		parents = append(parents, interCert.Certificate)
-		signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", interCert, sigalg, false)
-		if err != nil {
-			t.Fatalf("test case %d sigalg %s: cannot generate signer cert: %s", i, sigalg, err)
-		}
-		toBeSigned, err := NewSignedData(content)
-		if err != nil {
-			t.Fatalf("test case %d sigalg %s: cannot initialize signed data: %s", i, sigalg, err)
-		}
-		if err := toBeSigned.AddSignerWithParents(signerCert.Certificate, *signerCert.PrivateKey, parents, SignerInfoConfig{}); err != nil {
-			t.Fatalf("Cannot add signer: %s", err)
-		}
-		toBeSigned.Detach()
-		signed, err := toBeSigned.Finish()
-		if err != nil {
-			t.Fatalf("test case %d sigalg %s: ccannot finish signing data: %s", i, sigalg, err)
-		}
-		pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
-
-		// write the root cert to a temp file
-		tmpRootCertFile, err := ioutil.TempFile("", "pkcs7TestRootCA")
-		if err != nil {
-			t.Fatal(err)
-		}
-		//defer os.Remove(tmpRootCertFile.Name()) // clean up
-		fd, err := os.OpenFile(tmpRootCertFile.Name(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-		if err != nil {
-			t.Fatal(err)
-		}
-		pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Certificate.Raw})
-		fd.Close()
-
-		// write the signature to a temp file
-		tmpSignatureFile, err := ioutil.TempFile("", "pkcs7Signature")
-		if err != nil {
-			t.Fatal(err)
-		}
-		//defer os.Remove(tmpSignatureFile.Name()) // clean up
-		ioutil.WriteFile(tmpSignatureFile.Name(), signed, 0755)
-
-		// write the content to a temp file
-		tmpContentFile, err := ioutil.TempFile("", "pkcs7Content")
-		if err != nil {
-			t.Fatal(err)
-		}
-		//defer os.Remove(tmpContentFile.Name()) // clean up
-		ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
-
-		// call openssl to verify the signature on the content using the root
-		opensslCMD := exec.Command("openssl", "smime", "-verify",
-			"-in", tmpSignatureFile.Name(), "-inform", "DER",
-			"-content", tmpContentFile.Name(),
-			"-CAfile", tmpRootCertFile.Name())
-		out, err := opensslCMD.Output()
-		t.Logf("%s", out)
-		if err != nil {
-			t.Fatalf("test case %d sigalg %s: openssl command failed with %s", i, sigalg, err)
-		}
-	}
-}
-
-func TestEncrypt(t *testing.T) {
-	modes := []int{
-		EncryptionAlgorithmDESCBC,
-		EncryptionAlgorithmAES128GCM,
-	}
-	sigalgs := []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
-		x509.SHA256WithRSA,
-		x509.SHA512WithRSA,
-	}
-	for _, mode := range modes {
-		for _, sigalg := range sigalgs {
-			ContentEncryptionAlgorithm = mode
-
-			plaintext := []byte("Hello Secret World!")
-			cert, err := createTestCertificate(sigalg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			encrypted, err := Encrypt(plaintext, []*x509.Certificate{cert.Certificate})
-			if err != nil {
-				t.Fatal(err)
-			}
-			p7, err := Parse(encrypted)
-			if err != nil {
-				t.Fatalf("cannot Parse encrypted result: %s", err)
-			}
-			result, err := p7.Decrypt(cert.Certificate, *cert.PrivateKey)
-			if err != nil {
-				t.Fatalf("cannot Decrypt encrypted result: %s", err)
-			}
-			if bytes.Compare(plaintext, result) != 0 {
-				t.Errorf("encrypted data does not match plaintext:\n\tExpected: %s\n\tActual: %s", plaintext, result)
-			}
-		}
-	}
-}
-
-func TestUnmarshalSignedAttribute(t *testing.T) {
-	cert, err := createTestCertificate(x509.SHA512WithRSA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	content := []byte("Hello World")
-	toBeSigned, err := NewSignedData(content)
-	if err != nil {
-		t.Fatalf("Cannot initialize signed data: %s", err)
-	}
-	oidTest := asn1.ObjectIdentifier{2, 3, 4, 5, 6, 7}
-	testValue := "TestValue"
-	if err := toBeSigned.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{
-		ExtraSignedAttributes: []Attribute{Attribute{Type: oidTest, Value: testValue}},
-	}); err != nil {
-		t.Fatalf("Cannot add signer: %s", err)
-	}
-	signed, err := toBeSigned.Finish()
-	if err != nil {
-		t.Fatalf("Cannot finish signing data: %s", err)
-	}
-	p7, err := Parse(signed)
-	var actual string
-	err = p7.UnmarshalSignedAttribute(oidTest, &actual)
-	if err != nil {
-		t.Fatalf("Cannot unmarshal test value: %s", err)
-	}
-	if testValue != actual {
-		t.Errorf("Attribute does not match test value\n\tExpected: %s\n\tActual: %s", testValue, actual)
-	}
-}
-
-func TestPad(t *testing.T) {
-	tests := []struct {
-		Original  []byte
-		Expected  []byte
-		BlockSize int
-	}{
-		{[]byte{0x1, 0x2, 0x3, 0x10}, []byte{0x1, 0x2, 0x3, 0x10, 0x4, 0x4, 0x4, 0x4}, 8},
-		{[]byte{0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0}, []byte{0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8}, 8},
-	}
-	for _, test := range tests {
-		padded, err := pad(test.Original, test.BlockSize)
-		if err != nil {
-			t.Errorf("pad encountered error: %s", err)
-			continue
-		}
-		if bytes.Compare(test.Expected, padded) != 0 {
-			t.Errorf("pad results mismatch:\n\tExpected: %X\n\tActual: %X", test.Expected, padded)
-		}
-	}
-}
 
 var test1024Key, test2048Key, test3072Key, test4096Key *rsa.PrivateKey
 
@@ -528,34 +119,86 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageEmailProtection},
 	}
+	if issuer != nil {
+		issuerCert = issuer.Certificate
+		issuerKey = *issuer.PrivateKey
+	}
 	switch sigAlg {
 	case x509.SHA1WithRSA:
 		priv = test1024Key
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA1WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA1
+		}
 	case x509.SHA256WithRSA:
 		priv = test2048Key
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA256WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA256
+		}
 	case x509.SHA384WithRSA:
 		priv = test3072Key
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA384WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA384
+		}
 	case x509.SHA512WithRSA:
 		priv = test4096Key
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA512WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA512
+		}
 	case x509.ECDSAWithSHA1:
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
 			return nil, err
+		}
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA1WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA1
 		}
 	case x509.ECDSAWithSHA256:
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
 			return nil, err
 		}
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA256WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA256
+		}
 	case x509.ECDSAWithSHA384:
 		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		if err != nil {
 			return nil, err
 		}
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA384WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA384
+		}
 	case x509.ECDSAWithSHA512:
 		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 		if err != nil {
 			return nil, err
+		}
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA512WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA512
 		}
 	}
 	if isCA {
@@ -563,16 +206,12 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		template.KeyUsage |= x509.KeyUsageCertSign
 		template.BasicConstraintsValid = true
 	}
-	if issuer != nil {
-		template.SignatureAlgorithm = 0
-		issuerCert = issuer.Certificate
-		issuerKey = *issuer.PrivateKey
-	} else {
+	if issuer == nil {
 		// no issuer given,make this a self-signed root cert
 		issuerCert = &template
 		issuerKey = priv
-		template.SignatureAlgorithm = sigAlg
 	}
+
 	log.Println("creating cert", name, "issued by", issuerCert.Subject.CommonName, "with sigalg", sigAlg)
 	switch priv.(type) {
 	case *rsa.PrivateKey:
@@ -634,387 +273,3 @@ func UnmarshalTestFixture(testPEMBlock string) TestFixture {
 
 	return result
 }
-
-func MarshalTestFixture(t TestFixture, w io.Writer) {
-	if t.Input != nil {
-		pem.Encode(w, &pem.Block{Type: "PKCS7", Bytes: t.Input})
-	}
-	if t.Certificate != nil {
-		pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: t.Certificate.Raw})
-	}
-	if t.PrivateKey != nil {
-		pem.Encode(w, &pem.Block{Type: "PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(t.PrivateKey)})
-	}
-}
-
-var SignedTestFixture = `
------BEGIN PKCS7-----
-MIIDVgYJKoZIhvcNAQcCoIIDRzCCA0MCAQExCTAHBgUrDgMCGjAcBgkqhkiG9w0B
-BwGgDwQNV2UgdGhlIFBlb3BsZaCCAdkwggHVMIIBQKADAgECAgRpuDctMAsGCSqG
-SIb3DQEBCzApMRAwDgYDVQQKEwdBY21lIENvMRUwEwYDVQQDEwxFZGRhcmQgU3Rh
-cmswHhcNMTUwNTA2MDQyNDQ4WhcNMTYwNTA2MDQyNDQ4WjAlMRAwDgYDVQQKEwdB
-Y21lIENvMREwDwYDVQQDEwhKb24gU25vdzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
-gYkCgYEAqr+tTF4mZP5rMwlXp1y+crRtFpuLXF1zvBZiYMfIvAHwo1ta8E1IcyEP
-J1jIiKMcwbzeo6kAmZzIJRCTezq9jwXUsKbQTvcfOH9HmjUmXBRWFXZYoQs/OaaF
-a45deHmwEeMQkuSWEtYiVKKZXtJOtflKIT3MryJEDiiItMkdybUCAwEAAaMSMBAw
-DgYDVR0PAQH/BAQDAgCgMAsGCSqGSIb3DQEBCwOBgQDK1EweZWRL+f7Z+J0kVzY8
-zXptcBaV4Lf5wGZJLJVUgp33bpLNpT3yadS++XQJ+cvtW3wADQzBSTMduyOF8Zf+
-L7TjjrQ2+F2HbNbKUhBQKudxTfv9dJHdKbD+ngCCdQJYkIy2YexsoNG0C8nQkggy
-axZd/J69xDVx6pui3Sj8sDGCATYwggEyAgEBMDEwKTEQMA4GA1UEChMHQWNtZSBD
-bzEVMBMGA1UEAxMMRWRkYXJkIFN0YXJrAgRpuDctMAcGBSsOAwIaoGEwGAYJKoZI
-hvcNAQkDMQsGCSqGSIb3DQEHATAgBgkqhkiG9w0BCQUxExcRMTUwNTA2MDAyNDQ4
-LTA0MDAwIwYJKoZIhvcNAQkEMRYEFG9D7gcTh9zfKiYNJ1lgB0yTh4sZMAsGCSqG
-SIb3DQEBAQSBgFF3sGDU9PtXty/QMtpcFa35vvIOqmWQAIZt93XAskQOnBq4OloX
-iL9Ct7t1m4pzjRm0o9nDkbaSLZe7HKASHdCqijroScGlI8M+alJ8drHSFv6ZIjnM
-FIwIf0B2Lko6nh9/6mUXq7tbbIHa3Gd1JUVire/QFFtmgRXMbXYk8SIS
------END PKCS7-----
------BEGIN CERTIFICATE-----
-MIIB1TCCAUCgAwIBAgIEabg3LTALBgkqhkiG9w0BAQswKTEQMA4GA1UEChMHQWNt
-ZSBDbzEVMBMGA1UEAxMMRWRkYXJkIFN0YXJrMB4XDTE1MDUwNjA0MjQ0OFoXDTE2
-MDUwNjA0MjQ0OFowJTEQMA4GA1UEChMHQWNtZSBDbzERMA8GA1UEAxMISm9uIFNu
-b3cwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKq/rUxeJmT+azMJV6dcvnK0
-bRabi1xdc7wWYmDHyLwB8KNbWvBNSHMhDydYyIijHMG83qOpAJmcyCUQk3s6vY8F
-1LCm0E73Hzh/R5o1JlwUVhV2WKELPzmmhWuOXXh5sBHjEJLklhLWIlSimV7STrX5
-SiE9zK8iRA4oiLTJHcm1AgMBAAGjEjAQMA4GA1UdDwEB/wQEAwIAoDALBgkqhkiG
-9w0BAQsDgYEAytRMHmVkS/n+2fidJFc2PM16bXAWleC3+cBmSSyVVIKd926SzaU9
-8mnUvvl0CfnL7Vt8AA0MwUkzHbsjhfGX/i+04460Nvhdh2zWylIQUCrncU37/XSR
-3Smw/p4AgnUCWJCMtmHsbKDRtAvJ0JIIMmsWXfyevcQ1ceqbot0o/LA=
------END CERTIFICATE-----
------BEGIN PRIVATE KEY-----
-MIICXgIBAAKBgQCqv61MXiZk/mszCVenXL5ytG0Wm4tcXXO8FmJgx8i8AfCjW1rw
-TUhzIQ8nWMiIoxzBvN6jqQCZnMglEJN7Or2PBdSwptBO9x84f0eaNSZcFFYVdlih
-Cz85poVrjl14ebAR4xCS5JYS1iJUople0k61+UohPcyvIkQOKIi0yR3JtQIDAQAB
-AoGBAIPLCR9N+IKxodq11lNXEaUFwMHXc1zqwP8no+2hpz3+nVfplqqubEJ4/PJY
-5AgbJoIfnxVhyBXJXu7E+aD/OPneKZrgp58YvHKgGvvPyJg2gpC/1Fh0vQB0HNpI
-1ZzIZUl8ZTUtVgtnCBUOh5JGI4bFokAqrT//Uvcfd+idgxqBAkEA1ZbP/Kseld14
-qbWmgmU5GCVxsZRxgR1j4lG3UVjH36KXMtRTm1atAam1uw3OEGa6Y3ANjpU52FaB
-Hep5rkk4FQJBAMynMo1L1uiN5GP+KYLEF5kKRxK+FLjXR0ywnMh+gpGcZDcOae+J
-+t1gLoWBIESH/Xt639T7smuSfrZSA9V0EyECQA8cvZiWDvLxmaEAXkipmtGPjKzQ
-4PsOtkuEFqFl07aKDYKmLUg3aMROWrJidqsIabWxbvQgsNgSvs38EiH3wkUCQQCg
-ndxb7piVXb9RBwm3OoU2tE1BlXMX+sVXmAkEhd2dwDsaxrI3sHf1xGXem5AimQRF
-JBOFyaCnMotGNioSHY5hAkEAxyXcNixQ2RpLXJTQZtwnbk0XDcbgB+fBgXnv/4f3
-BCvcu85DqJeJyQv44Oe1qsXEX9BfcQIOVaoep35RPlKi9g==
------END PRIVATE KEY-----`
-
-// Content is "This is a test"
-var EncryptedTestFixture = `
------BEGIN PKCS7-----
-MIIBFwYJKoZIhvcNAQcDoIIBCDCCAQQCAQAxgcowgccCAQAwMjApMRAwDgYDVQQK
-EwdBY21lIENvMRUwEwYDVQQDEwxFZGRhcmQgU3RhcmsCBQDL+CvWMAsGCSqGSIb3
-DQEBAQSBgKyP/5WlRTZD3dWMrLOX6QRNDrXEkQjhmToRwFZdY3LgUh25ZU0S/q4G
-dHPV21Fv9lQD+q7l3vfeHw8M6Z1PKi9sHMVfxAkQpvaI96DTIT3YHtuLC1w3geCO
-8eFWTq2qS4WChSuS/yhYosjA1kTkE0eLnVZcGw0z/WVuEZznkdyIMDIGCSqGSIb3
-DQEHATARBgUrDgMCBwQImpKsUyMPpQigEgQQRcWWrCRXqpD5Njs0GkJl+g==
------END PKCS7-----
------BEGIN CERTIFICATE-----
-MIIB1jCCAUGgAwIBAgIFAMv4K9YwCwYJKoZIhvcNAQELMCkxEDAOBgNVBAoTB0Fj
-bWUgQ28xFTATBgNVBAMTDEVkZGFyZCBTdGFyazAeFw0xNTA1MDYwMzU2NDBaFw0x
-NjA1MDYwMzU2NDBaMCUxEDAOBgNVBAoTB0FjbWUgQ28xETAPBgNVBAMTCEpvbiBT
-bm93MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDK6NU0R0eiCYVquU4RcjKc
-LzGfx0aa1lMr2TnLQUSeLFZHFxsyyMXXuMPig3HK4A7SGFHupO+/1H/sL4xpH5zg
-8+Zg2r8xnnney7abxcuv0uATWSIeKlNnb1ZO1BAxFnESc3GtyOCr2dUwZHX5mRVP
-+Zxp2ni5qHNraf3wE2VPIQIDAQABoxIwEDAOBgNVHQ8BAf8EBAMCAKAwCwYJKoZI
-hvcNAQELA4GBAIr2F7wsqmEU/J/kLyrCgEVXgaV/sKZq4pPNnzS0tBYk8fkV3V18
-sBJyHKRLL/wFZASvzDcVGCplXyMdAOCyfd8jO3F9Ac/xdlz10RrHJT75hNu3a7/n
-9KNwKhfN4A1CQv2x372oGjRhCW5bHNCWx4PIVeNzCyq/KZhyY9sxHE6f
------END CERTIFICATE-----
------BEGIN PRIVATE KEY-----
-MIICXgIBAAKBgQDK6NU0R0eiCYVquU4RcjKcLzGfx0aa1lMr2TnLQUSeLFZHFxsy
-yMXXuMPig3HK4A7SGFHupO+/1H/sL4xpH5zg8+Zg2r8xnnney7abxcuv0uATWSIe
-KlNnb1ZO1BAxFnESc3GtyOCr2dUwZHX5mRVP+Zxp2ni5qHNraf3wE2VPIQIDAQAB
-AoGBALyvnSt7KUquDen7nXQtvJBudnf9KFPt//OjkdHHxNZNpoF/JCSqfQeoYkeu
-MdAVYNLQGMiRifzZz4dDhA9xfUAuy7lcGQcMCxEQ1dwwuFaYkawbS0Tvy2PFlq2d
-H5/HeDXU4EDJ3BZg0eYj2Bnkt1sJI35UKQSxblQ0MY2q0uFBAkEA5MMOogkgUx1C
-67S1tFqMUSM8D0mZB0O5vOJZC5Gtt2Urju6vywge2ArExWRXlM2qGl8afFy2SgSv
-Xk5eybcEiQJBAOMRwwbEoW5NYHuFFbSJyWll4n71CYuWuQOCzehDPyTb80WFZGLV
-i91kFIjeERyq88eDE5xVB3ZuRiXqaShO/9kCQQCKOEkpInaDgZSjskZvuJ47kByD
-6CYsO4GIXQMMeHML8ncFH7bb6AYq5ybJVb2NTU7QLFJmfeYuhvIm+xdOreRxAkEA
-o5FC5Jg2FUfFzZSDmyZ6IONUsdF/i78KDV5nRv1R+hI6/oRlWNCtTNBv/lvBBd6b
-dseUE9QoaQZsn5lpILEvmQJAZ0B+Or1rAYjnbjnUhdVZoy9kC4Zov+4UH3N/BtSy
-KJRWUR0wTWfZBPZ5hAYZjTBEAFULaYCXlQKsODSp0M1aQA==
------END PRIVATE KEY-----`
-
-var EC2IdentityDocumentFixture = `
------BEGIN PKCS7-----
-MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqGSIb3DQEHAaCA
-JIAEggGmewogICJwcml2YXRlSXAiIDogIjE3Mi4zMC4wLjI1MiIsCiAgImRldnBh
-eVByb2R1Y3RDb2RlcyIgOiBudWxsLAogICJhdmFpbGFiaWxpdHlab25lIiA6ICJ1
-cy1lYXN0LTFhIiwKICAidmVyc2lvbiIgOiAiMjAxMC0wOC0zMSIsCiAgImluc3Rh
-bmNlSWQiIDogImktZjc5ZmU1NmMiLAogICJiaWxsaW5nUHJvZHVjdHMiIDogbnVs
-bCwKICAiaW5zdGFuY2VUeXBlIiA6ICJ0Mi5taWNybyIsCiAgImFjY291bnRJZCIg
-OiAiMTIxNjU5MDE0MzM0IiwKICAiaW1hZ2VJZCIgOiAiYW1pLWZjZTNjNjk2IiwK
-ICAicGVuZGluZ1RpbWUiIDogIjIwMTYtMDQtMDhUMDM6MDE6MzhaIiwKICAiYXJj
-aGl0ZWN0dXJlIiA6ICJ4ODZfNjQiLAogICJrZXJuZWxJZCIgOiBudWxsLAogICJy
-YW1kaXNrSWQiIDogbnVsbCwKICAicmVnaW9uIiA6ICJ1cy1lYXN0LTEiCn0AAAAA
-AAAxggEYMIIBFAIBATBpMFwxCzAJBgNVBAYTAlVTMRkwFwYDVQQIExBXYXNoaW5n
-dG9uIFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYDVQQKExdBbWF6b24gV2Vi
-IFNlcnZpY2VzIExMQwIJAJa6SNnlXhpnMAkGBSsOAwIaBQCgXTAYBgkqhkiG9w0B
-CQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0xNjA0MDgwMzAxNDRaMCMG
-CSqGSIb3DQEJBDEWBBTuUc28eBXmImAautC+wOjqcFCBVjAJBgcqhkjOOAQDBC8w
-LQIVAKA54NxGHWWCz5InboDmY/GHs33nAhQ6O/ZI86NwjA9Vz3RNMUJrUPU5tAAA
-AAAAAA==
------END PKCS7-----
------BEGIN CERTIFICATE-----
-MIIC7TCCAq0CCQCWukjZ5V4aZzAJBgcqhkjOOAQDMFwxCzAJBgNVBAYTAlVTMRkw
-FwYDVQQIExBXYXNoaW5ndG9uIFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYD
-VQQKExdBbWF6b24gV2ViIFNlcnZpY2VzIExMQzAeFw0xMjAxMDUxMjU2MTJaFw0z
-ODAxMDUxMjU2MTJaMFwxCzAJBgNVBAYTAlVTMRkwFwYDVQQIExBXYXNoaW5ndG9u
-IFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYDVQQKExdBbWF6b24gV2ViIFNl
-cnZpY2VzIExMQzCCAbcwggEsBgcqhkjOOAQBMIIBHwKBgQCjkvcS2bb1VQ4yt/5e
-ih5OO6kK/n1Lzllr7D8ZwtQP8fOEpp5E2ng+D6Ud1Z1gYipr58Kj3nssSNpI6bX3
-VyIQzK7wLclnd/YozqNNmgIyZecN7EglK9ITHJLP+x8FtUpt3QbyYXJdmVMegN6P
-hviYt5JH/nYl4hh3Pa1HJdskgQIVALVJ3ER11+Ko4tP6nwvHwh6+ERYRAoGBAI1j
-k+tkqMVHuAFcvAGKocTgsjJem6/5qomzJuKDmbJNu9Qxw3rAotXau8Qe+MBcJl/U
-hhy1KHVpCGl9fueQ2s6IL0CaO/buycU1CiYQk40KNHCcHfNiZbdlx1E9rpUp7bnF
-lRa2v1ntMX3caRVDdbtPEWmdxSCYsYFDk4mZrOLBA4GEAAKBgEbmeve5f8LIE/Gf
-MNmP9CM5eovQOGx5ho8WqD+aTebs+k2tn92BBPqeZqpWRa5P/+jrdKml1qx4llHW
-MXrs3IgIb6+hUIB+S8dz8/mmO0bpr76RoZVCXYab2CZedFut7qc3WUH9+EUAH5mw
-vSeDCOUMYQR7R9LINYwouHIziqQYMAkGByqGSM44BAMDLwAwLAIUWXBlk40xTwSw
-7HX32MxXYruse9ACFBNGmdX2ZBrVNGrN9N2f6ROk0k9K
------END CERTIFICATE-----`
-
-var AppStoreReceiptFixture = `
------BEGIN PKCS7-----
-MIITtgYJKoZIhvcNAQcCoIITpzCCE6MCAQExCzAJBgUrDgMCGgUAMIIDVwYJKoZI
-hvcNAQcBoIIDSASCA0QxggNAMAoCAQgCAQEEAhYAMAoCARQCAQEEAgwAMAsCAQEC
-AQEEAwIBADALAgEDAgEBBAMMATEwCwIBCwIBAQQDAgEAMAsCAQ8CAQEEAwIBADAL
-AgEQAgEBBAMCAQAwCwIBGQIBAQQDAgEDMAwCAQoCAQEEBBYCNCswDAIBDgIBAQQE
-AgIAjTANAgENAgEBBAUCAwFgvTANAgETAgEBBAUMAzEuMDAOAgEJAgEBBAYCBFAy
-NDcwGAIBAgIBAQQQDA5jb20uemhpaHUudGVzdDAYAgEEAgECBBCS+ZODNMHwT1Nz
-gWYDXyWZMBsCAQACAQEEEwwRUHJvZHVjdGlvblNhbmRib3gwHAIBBQIBAQQU4nRh
-YCEZx70Flzv7hvJRjJZckYIwHgIBDAIBAQQWFhQyMDE2LTA3LTIzVDA2OjIxOjEx
-WjAeAgESAgEBBBYWFDIwMTMtMDgtMDFUMDc6MDA6MDBaMD0CAQYCAQEENbR21I+a
-8+byMXo3NPRoDWQmSXQF2EcCeBoD4GaL//ZCRETp9rGFPSg1KekCP7Kr9HAqw09m
-MEICAQcCAQEEOlVJozYYBdugybShbiiMsejDMNeCbZq6CrzGBwW6GBy+DGWxJI91
-Y3ouXN4TZUhuVvLvN1b0m5T3ggQwggFaAgERAgEBBIIBUDGCAUwwCwICBqwCAQEE
-AhYAMAsCAgatAgEBBAIMADALAgIGsAIBAQQCFgAwCwICBrICAQEEAgwAMAsCAgaz
-AgEBBAIMADALAgIGtAIBAQQCDAAwCwICBrUCAQEEAgwAMAsCAga2AgEBBAIMADAM
-AgIGpQIBAQQDAgEBMAwCAgarAgEBBAMCAQEwDAICBq4CAQEEAwIBADAMAgIGrwIB
-AQQDAgEAMAwCAgaxAgEBBAMCAQAwGwICBqcCAQEEEgwQMTAwMDAwMDIyNTMyNTkw
-MTAbAgIGqQIBAQQSDBAxMDAwMDAwMjI1MzI1OTAxMB8CAgaoAgEBBBYWFDIwMTYt
-MDctMjNUMDY6MjE6MTFaMB8CAgaqAgEBBBYWFDIwMTYtMDctMjNUMDY6MjE6MTFa
-MCACAgamAgEBBBcMFWNvbS56aGlodS50ZXN0LnRlc3RfMaCCDmUwggV8MIIEZKAD
-AgECAggO61eH554JjTANBgkqhkiG9w0BAQUFADCBljELMAkGA1UEBhMCVVMxEzAR
-BgNVBAoMCkFwcGxlIEluYy4xLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZl
-bG9wZXIgUmVsYXRpb25zMUQwQgYDVQQDDDtBcHBsZSBXb3JsZHdpZGUgRGV2ZWxv
-cGVyIFJlbGF0aW9ucyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0xNTExMTMw
-MjE1MDlaFw0yMzAyMDcyMTQ4NDdaMIGJMTcwNQYDVQQDDC5NYWMgQXBwIFN0b3Jl
-IGFuZCBpVHVuZXMgU3RvcmUgUmVjZWlwdCBTaWduaW5nMSwwKgYDVQQLDCNBcHBs
-ZSBXb3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9uczETMBEGA1UECgwKQXBwbGUg
-SW5jLjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
-AQClz4H9JaKBW9aH7SPaMxyO4iPApcQmyz3Gn+xKDVWG/6QC15fKOVRtfX+yVBid
-xCxScY5ke4LOibpJ1gjltIhxzz9bRi7GxB24A6lYogQ+IXjV27fQjhKNg0xbKmg3
-k8LyvR7E0qEMSlhSqxLj7d0fmBWQNS3CzBLKjUiB91h4VGvojDE2H0oGDEdU8zeQ
-uLKSiX1fpIVK4cCc4Lqku4KXY/Qrk8H9Pm/KwfU8qY9SGsAlCnYO3v6Z/v/Ca/Vb
-XqxzUUkIVonMQ5DMjoEC0KCXtlyxoWlph5AQaCYmObgdEHOwCl3Fc9DfdjvYLdmI
-HuPsB8/ijtDT+iZVge/iA0kjAgMBAAGjggHXMIIB0zA/BggrBgEFBQcBAQQzMDEw
-LwYIKwYBBQUHMAGGI2h0dHA6Ly9vY3NwLmFwcGxlLmNvbS9vY3NwMDMtd3dkcjA0
-MB0GA1UdDgQWBBSRpJz8xHa3n6CK9E31jzZd7SsEhTAMBgNVHRMBAf8EAjAAMB8G
-A1UdIwQYMBaAFIgnFwmpthhgi+zruvZHWcVSVKO3MIIBHgYDVR0gBIIBFTCCAREw
-ggENBgoqhkiG92NkBQYBMIH+MIHDBggrBgEFBQcCAjCBtgyBs1JlbGlhbmNlIG9u
-IHRoaXMgY2VydGlmaWNhdGUgYnkgYW55IHBhcnR5IGFzc3VtZXMgYWNjZXB0YW5j
-ZSBvZiB0aGUgdGhlbiBhcHBsaWNhYmxlIHN0YW5kYXJkIHRlcm1zIGFuZCBjb25k
-aXRpb25zIG9mIHVzZSwgY2VydGlmaWNhdGUgcG9saWN5IGFuZCBjZXJ0aWZpY2F0
-aW9uIHByYWN0aWNlIHN0YXRlbWVudHMuMDYGCCsGAQUFBwIBFipodHRwOi8vd3d3
-LmFwcGxlLmNvbS9jZXJ0aWZpY2F0ZWF1dGhvcml0eS8wDgYDVR0PAQH/BAQDAgeA
-MBAGCiqGSIb3Y2QGCwEEAgUAMA0GCSqGSIb3DQEBBQUAA4IBAQANphvTLj3jWysH
-bkKWbNPojEMwgl/gXNGNvr0PvRr8JZLbjIXDgFnf4+LXLgUUrA3btrj+/DUufMut
-F2uOfx/kd7mxZ5W0E16mGYZ2+FogledjjA9z/Ojtxh+umfhlSFyg4Cg6wBA3Lbmg
-BDkfc7nIBf3y3n8aKipuKwH8oCBc2et9J6Yz+PWY4L5E27FMZ/xuCk/J4gao0pfz
-p45rUaJahHVl0RYEYuPBX/UIqc9o2ZIAycGMs/iNAGS6WGDAfK+PdcppuVsq1h1o
-bphC9UynNxmbzDscehlD86Ntv0hgBgw2kivs3hi1EdotI9CO/KBpnBcbnoB7OUdF
-MGEvxxOoMIIEIjCCAwqgAwIBAgIIAd68xDltoBAwDQYJKoZIhvcNAQEFBQAwYjEL
-MAkGA1UEBhMCVVMxEzARBgNVBAoTCkFwcGxlIEluYy4xJjAkBgNVBAsTHUFwcGxl
-IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRYwFAYDVQQDEw1BcHBsZSBSb290IENB
-MB4XDTEzMDIwNzIxNDg0N1oXDTIzMDIwNzIxNDg0N1owgZYxCzAJBgNVBAYTAlVT
-MRMwEQYDVQQKDApBcHBsZSBJbmMuMSwwKgYDVQQLDCNBcHBsZSBXb3JsZHdpZGUg
-RGV2ZWxvcGVyIFJlbGF0aW9uczFEMEIGA1UEAww7QXBwbGUgV29ybGR3aWRlIERl
-dmVsb3BlciBSZWxhdGlvbnMgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwggEiMA0G
-CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKOFSmy1aqyCQ5SOmM7uxfuH8mkbw0
-U3rOfGOAYXdkXqUHI7Y5/lAtFVZYcC1+xG7BSoU+L/DehBqhV8mvexj/avoVEkkV
-CBmsqtsqMu2WY2hSFT2Miuy/axiV4AOsAX2XBWfODoWVN2rtCbauZ81RZJ/GXNG8
-V25nNYB2NqSHgW44j9grFU57Jdhav06DwY3Sk9UacbVgnJ0zTlX5ElgMhrgWDcHl
-d0WNUEi6Ky3klIXh6MSdxmilsKP8Z35wugJZS3dCkTm59c3hTO/AO0iMpuUhXf1q
-arunFjVg0uat80YpyejDi+l5wGphZxWy8P3laLxiX27Pmd3vG2P+kmWrAgMBAAGj
-gaYwgaMwHQYDVR0OBBYEFIgnFwmpthhgi+zruvZHWcVSVKO3MA8GA1UdEwEB/wQF
-MAMBAf8wHwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/CF4wLgYDVR0fBCcw
-JTAjoCGgH4YdaHR0cDovL2NybC5hcHBsZS5jb20vcm9vdC5jcmwwDgYDVR0PAQH/
-BAQDAgGGMBAGCiqGSIb3Y2QGAgEEAgUAMA0GCSqGSIb3DQEBBQUAA4IBAQBPz+9Z
-viz1smwvj+4ThzLoBTWobot9yWkMudkXvHcs1Gfi/ZptOllc34MBvbKuKmFysa/N
-w0Uwj6ODDc4dR7Txk4qjdJukw5hyhzs+r0ULklS5MruQGFNrCk4QttkdUGwhgAqJ
-TleMa1s8Pab93vcNIx0LSiaHP7qRkkykGRIZbVf1eliHe2iK5IaMSuviSRSqpd1V
-AKmuu0swruGgsbwpgOYJd+W+NKIByn/c4grmO7i77LpilfMFY0GCzQ87HUyVpNur
-+cmV6U/kTecmmYHpvPm0KdIBembhLoz2IYrF+Hjhga6/05Cdqa3zr/04GpZnMBxR
-pVzscYqCtGwPDBUfMIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQsw
-CQYDVQQGEwJVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUg
-Q2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0Ew
-HhcNMDYwNDI1MjE0MDM2WhcNMzUwMjA5MjE0MDM2WjBiMQswCQYDVQQGEwJVUzET
-MBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlv
-biBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwggEiMA0GCSqGSIb3
-DQEBAQUAA4IBDwAwggEKAoIBAQDkkakJH5HbHkdQ6wXtXnmELes2oldMVeyLGYne
-+Uts9QerIjAC6Bg++FAJ039BqJj50cpmnCRrEdCju+QbKsMflZ56DKRHi1vUFjcz
-y8QPTc4UadHJGXL1XQ7Vf1+b8iUDulWPTV0N8WQ1IxVLFVkds5T39pyez1C6wVhQ
-Z48ItCD3y6wsIG9wtj8BMIy3Q88PnT3zK0koGsj+zrW5DtleHNbLPbU6rfQPDgCS
-C7EhFi501TwN22IWq6NxkkdTVcGvL0Gz+PvjcM3mo0xFfh9Ma1CWQYnEdGILEINB
-hzOKgbEwWOxaBDKMaLOPHd5lc/9nXmW8Sdh2nzMUZaF3lMktAgMBAAGjggF6MIIB
-djAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUK9Bp
-R5R2Cf70a40uQKb3R01/CF4wHwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/
-CF4wggERBgNVHSAEggEIMIIBBDCCAQAGCSqGSIb3Y2QFATCB8jAqBggrBgEFBQcC
-ARYeaHR0cHM6Ly93d3cuYXBwbGUuY29tL2FwcGxlY2EvMIHDBggrBgEFBQcCAjCB
-thqBs1JlbGlhbmNlIG9uIHRoaXMgY2VydGlmaWNhdGUgYnkgYW55IHBhcnR5IGFz
-c3VtZXMgYWNjZXB0YW5jZSBvZiB0aGUgdGhlbiBhcHBsaWNhYmxlIHN0YW5kYXJk
-IHRlcm1zIGFuZCBjb25kaXRpb25zIG9mIHVzZSwgY2VydGlmaWNhdGUgcG9saWN5
-IGFuZCBjZXJ0aWZpY2F0aW9uIHByYWN0aWNlIHN0YXRlbWVudHMuMA0GCSqGSIb3
-DQEBBQUAA4IBAQBcNplMLXi37Yyb3PN3m/J20ncwT8EfhYOFG5k9RzfyqZtAjizU
-sZAS2L70c5vu0mQPy3lPNNiiPvl4/2vIB+x9OYOLUyDTOMSxv5pPCmv/K/xZpwUJ
-fBdAVhEedNO3iyM7R6PVbyTi69G3cN8PReEnyvFteO3ntRcXqNx+IjXKJdXZD9Zr
-1KIkIxH3oayPc4FgxhtbCS+SsvhESPBgOJ4V9T0mZyCKM2r3DYLP3uujL/lTaltk
-wGMzd/c6ByxW69oPIQ7aunMZT7XZNn/Bh1XZp5m5MkL72NVxnn6hUrcbvZNCJBIq
-xw8dtk2cXmPIS4AXUKqK1drk/NAJBzewdXUhMYIByzCCAccCAQEwgaMwgZYxCzAJ
-BgNVBAYTAlVTMRMwEQYDVQQKDApBcHBsZSBJbmMuMSwwKgYDVQQLDCNBcHBsZSBX
-b3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9uczFEMEIGA1UEAww7QXBwbGUgV29y
-bGR3aWRlIERldmVsb3BlciBSZWxhdGlvbnMgQ2VydGlmaWNhdGlvbiBBdXRob3Jp
-dHkCCA7rV4fnngmNMAkGBSsOAwIaBQAwDQYJKoZIhvcNAQEBBQAEggEAasPtnide
-NWyfUtewW9OSgcQA8pW+5tWMR0469cBPZR84uJa0gyfmPspySvbNOAwnrwzZHYLa
-ujOxZLip4DUw4F5s3QwUa3y4BXpF4J+NSn9XNvxNtnT/GcEQtCuFwgJ0o3F0ilhv
-MTHrwiwyx/vr+uNDqlORK8lfK+1qNp+A/kzh8eszMrn4JSeTh9ZYxLHE56WkTQGD
-VZXl0gKgxSOmDrcp1eQxdlymzrPv9U60wUJ0bkPfrU9qZj3mJrmrkQk61JTe3j6/
-QfjfFBG9JG2mUmYQP1KQ3SypGHzDW8vngvsGu//tNU0NFfOqQu4bYU4VpQl0nPtD
-4B85NkrgvQsWAQ==
------END PKCS7-----`
-
-var FirefoxAddonContent = []byte(`Signature-Version: 1.0
-MD5-Digest-Manifest: KjRavc6/KNpuT1QLcB/Gsg==
-SHA1-Digest-Manifest: 5Md5nUg+U7hQ/UfzV+xGKWOruVI=
-
-`)
-
-var FirefoxAddonFixture = `
------BEGIN PKCS7-----
-MIIQTAYJKoZIhvcNAQcCoIIQPTCCEDkCAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3
-DQEHAaCCDL0wggW6MIIDoqADAgECAgYBVpobWVwwDQYJKoZIhvcNAQELBQAwgcUx
-CzAJBgNVBAYTAlVTMRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYD
-VQQLEyZNb3ppbGxhIEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTExMC8G
-A1UEAxMocHJvZHVjdGlvbi1zaWduaW5nLWNhLmFkZG9ucy5tb3ppbGxhLm9yZzE0
-MDIGCSqGSIb3DQEJARYlc2VydmljZXMtb3BzK2FkZG9uc2lnbmluZ0Btb3ppbGxh
-LmNvbTAeFw0xNjA4MTcyMDA0NThaFw0yMTA4MTYyMDA0NThaMHYxEzARBgNVBAsT
-ClByb2R1Y3Rpb24xCzAJBgNVBAYTAlVTMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3
-MQ8wDQYDVQQKEwZBZGRvbnMxCzAJBgNVBAgTAkNBMRwwGgYDVQQDFBN0YWJzY29w
-ZUB4dWxkZXYub3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAv6e0
-mPD8dt4J8HTNNq4ODns2DV6Weh1hllCIFvOeu1u3UrR03st0BMY8OXYwr/NvRVjg
-bA8gRySWAL+XqLzbhtXNeNegAoxrF+3mYY5rJjsLj/FGI6P6OXjngqwgm9VTBl7m
-jh/KXBSwYoUcavJo6cmk8sCFwoblyQiv+tsWaUCOI6zMzubNtIS+GFvET9y/VZMP
-j6mk8O10wBgJF5MMtA19va3qXy7aCZ7DnZp1l3equd/L6t324TtXoqx6xWQKo6TM
-I0mcTlKvm6TKegTGBCyGn3JRARoIJv4AW1qqgyaHXf9EoY2pKT8Avkri5++NuSJ6
-jtO4k/diBA2MZU20U0KGffYZNTxKDqd6XtI6y1tJPd/OWRFyU+mHntkcm9sar7L3
-nPKujHRox2re10ec1WBnJE3PjlAoesNjxzp+xs2mGGc8DX9NuWn+1uK9xmgGIIMl
-OFfyQ4s0G6hKp5goFcrFZxmexu0ZahOs8vZf8xDBW7yR1zToQElOXHvrscM386os
-kOF9IxQZfcCoPuNQVg1haCONNkx0oau3RQQlOSAZtC79b+rBjQ5JYfjRLYAworf2
-xQaprCh33TD1dTBrvzEbCGszgkN53Vqh5TFBjbU/NyldOkGvK8Xf6WhT5u+aftnV
-lbuE2McAg6x1AlloUZq6PNTBpz7zypcIISnQ+y8CAwEAATANBgkqhkiG9w0BAQsF
-AAOCAgEAIBoo2+OEYNCgP/IbUj9azaf/lde1q4AK/uTMoUeS5WcrXd8aqA0Y1qV7
-xUALgDQAExXgqcOMGu4mPMaoZDgwGI4Tj7XPJQq5Z5zYxpRf/Wtzae33T9BF6QPW
-v5xiRYuol+FbEtqRHZqxDWtIrd1MWBy3wjO3pLPdzDM9jWh+HLxdGWThJszaZp3T
-CqsOx+l9W0Q7qM5ioZpHStgXDfhw38Lg++kLnzcX9MqsjYyezdwE4krqW6hK3+4S
-0LZE4dTgsy8JULkyAF3HrPWEXESnD7c4mx6owZe+BNDK5hsVM/obAqH7sJq/igbM
-5N1l832p/ws8l5xKOr3qBWSzWn6u7ExvqG6Ckh0foJOVXvzGqvrXcoiBGV8S9Z7c
-DghUvMt6b0pZ0ildRCHfTUz7eG3g4MhfbjupR7b+L9FWEJhcd/H0dxpw7SKYha/n
-ePuRL7MXmbW8WLMqO/ImxzL8TPOB3pUg3nITfubV6gpPBmn+0nwbqYUmggJuwgvK
-I2GpN2Ny6EErZy17EEgyhJygJZMj+UzQjC781xxsl3ljpYEqqwgRLIZBSBUD5dXj
-XBuU24w162SeSyHZzkBbuv6lr52pqoZyFrG29DCHECgO9ZmNWgSpiWSkh+vExAG7
-wNs0y61t2HUG+BCMGPQ9sOzouyTfrnLVAWwzswGftFYQfoIBeJIwggb7MIIE46AD
-AgECAgMQAAIwDQYJKoZIhvcNAQEMBQAwfTELMAkGA1UEBhMCVVMxHDAaBgNVBAoT
-E01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEgQU1PIFByb2R1
-Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNhLXByb2R1Y3Rp
-b24tYW1vMB4XDTE1MDMxNzIzNTI0MloXDTI1MDMxNDIzNTI0MlowgcUxCzAJBgNV
-BAYTAlVTMRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYDVQQLEyZN
-b3ppbGxhIEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTExMC8GA1UEAxMo
-cHJvZHVjdGlvbi1zaWduaW5nLWNhLmFkZG9ucy5tb3ppbGxhLm9yZzE0MDIGCSqG
-SIb3DQEJARYlc2VydmljZXMtb3BzK2FkZG9uc2lnbmluZ0Btb3ppbGxhLmNvbTCC
-AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMLMM9m2HBLhCiO9mhljpehT
-hxpzlCnxluzDZ51I/H7MvBbIvZBm9zSpHdffubSsak2qYE69d+ebTa/CK83WIosM
-24/2Qp7n/GGaPJcCC4Y3JkrCsgA8+wV2MbFlKSv+qMdvI/sE3BPYDMCjVPMhHmIP
-XaPWd42OoHpI8R3GGUtVnR3Hm76pa2+v6TwgeMiO8om+ogGufiyv6FNMZ5NuY1Z9
-aLNEvehnAzSfddQyki+6FJd7XkgZbP7pb1Kl8yYgiy4piBerJ9H09uPehffE3Ell
-3cApQL3+0kjaUX4scMjuNQDMKziRZkYgJAM+qA9WA5Jn77AjerQBWQeEev1PWHYh
-0IDlgS/a0bjKmVjNZYG6adrY/R5/whzWGFCIE1UfhPm6PdN0557qvF838C2RFHsI
-KzV6KQf0chMjpa02tPaIctjVhnDQZZNKm2ZfLOt9kQ57Is/e6KxH7pYMit46+s99
-lYM7ZquvWbK19b1Ili/6S1BxSzd3wztgfN5jGsc+jCCYLm+AcVtfNKc8cFZHXKrB
-CwhGmdbWDSBCicZNA7FKJpO3oIx26VPF2XUldA/T5Mh/POGLilK3t9m9qbjEyDp1
-EwoBToOR/aMrdnNYvSWp0g/GHMzSfJjjXyAqrZY2itam/IJd8r9FoRAzevPt/zTX
-BET3INoiCDGRH0XrxUYtAgMGVTejggE5MIIBNTAMBgNVHRMEBTADAQH/MA4GA1Ud
-DwEB/wQEAwIBBjAWBgNVHSUBAf8EDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUdHxf
-FKXipZLjs20GqIUdNkQXH4gwgagGA1UdIwSBoDCBnYAUs7zqWHSr4W54KrKrnCMe
-qGMsl7ehgYGkfzB9MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jw
-b3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5n
-IFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW+CAQEwMwYJ
-YIZIAYb4QgEEBCYWJGh0dHA6Ly9hZGRvbnMubW96aWxsYS5vcmcvY2EvY3JsLnBl
-bTANBgkqhkiG9w0BAQwFAAOCAgEArde/fdjb7TE0eH7Ij7xU4JbcSyhY3cQhVYCw
-Fg+Q/2pj+NAfazcjUuLWA0Y/YZs9HOx6j+ZAqO4C/xfMP4RDs9IypxvzHDU6SXgD
-RK6uOKtS07HXLcXgFUBvJEQhbT/h5+IQOA4/GcpCshfD6iyiBBi+IocR+tnKPCuZ
-T3m1t60Eja/MkPKG/Gx8vSodHvlTTsJ2GzjUEANveCZOnlAdp9fjTvFZny9qqnbg
-sfVbuTqKndbCFW5QLXfkna6jBqMrY0+CpMYY2oJ5gwpHbE/7hhukjxGCTcpv7r/O
-M53bb/DZnybDlLLepacljvz7DBA1O1FFtEhf9MR+vyvmBpniAyKQhqG2hsVGurE1
-nBcE+oteZWar2lMp6+etDAb9DRC+jZv0aEQs2o/qQwyD8AGquLgBsJq5Jz3gGxzn
-4r3vGu2lV8VdzIm0C8sOFSWTmTZxQmJbF8xSsQBojnsvEah4DPER+eAt6qKolaWe
-s4drJQjzFyC7HJn2VqalpCwbe9CdMB7eRqzeP6GujJBi80/gx0pAysUtuKKpH5IJ
-WbXAOszfrjb3CaHafYZDnwPoOfj74ogFzjt2f54jwnU+ET/byfjZ7J8SLH316C1V
-HrvFXcTzyMV4aRluVPjPg9x1G58hMIbeuT4GpwQUNdJ9uL8t65v0XwG2t6Y7jpRO
-sFVxBtgxggNXMIIDUwIBATCB0DCBxTELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE01v
-emlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEgQU1PIFByb2R1Y3Rp
-b24gU2lnbmluZyBTZXJ2aWNlMTEwLwYDVQQDEyhwcm9kdWN0aW9uLXNpZ25pbmct
-Y2EuYWRkb25zLm1vemlsbGEub3JnMTQwMgYJKoZIhvcNAQkBFiVzZXJ2aWNlcy1v
-cHMrYWRkb25zaWduaW5nQG1vemlsbGEuY29tAgYBVpobWVwwCQYFKw4DAhoFAKBd
-MBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTE2MDgx
-NzIwMDQ1OFowIwYJKoZIhvcNAQkEMRYEFAxlGvNFSx+Jqj70haE8b7UZk+2GMA0G
-CSqGSIb3DQEBAQUABIICADsDlrucYRgwq9o2QSsO6X6cRa5Zu6w+1n07PTIyc1zn
-Pi1cgkkWZ0kZBHDrJ5CY33yRQPl6I1tHXaq7SkOSdOppKhpUmBiKZxQRAZR21QHk
-R3v1XS+st/o0N+0btv3YoplUifLIwtH89oolxqlStChELu7FuOBretdhx/z12ytA
-EhIIS53o/XjDL7XKJbQA02vzOtOC/Eq6p8BI7F3y6pvtmJIRkeGv+u6ssJa6g5q8
-74w8hHXaH94Z9+hDPqjNWlsXJHgPdAKiEjzDz9oLkvDyX4Pd8JMK5ILskirpG+hj
-Q8jkTc5oYwyuSlBAUTGxW6ZbuOrtfVZvOVtRL/ixuiFiVlJ+JOQOxrtK19ukamsI
-iacFlbLgiA7w0HCtm2DsT9aL67/1e4rJ0lv0MjnQYUMmKQy7g0Gd3+nQPU9pn+Lf
-Z/UmSNWiJ8Csc/seDMyzT6jrzcGPfoSVaUowH0wGrI9If1snwcr+mMg7dWRGf1fm
-y/dcVSzed0ax4LqDmike1EshU+51cKWWlnhyNHK4KH+0fNsBQ0c6clrFpGx9MPmV
-YXie6C+LWkh5x12RU0sJt/SmSZV6q9VliIkX+yY3jBrC/pKgRahtcIyq46Da1E6K
-lc15Euur3NfGow+nott0Z8XutpYdK/2vBKcIh9JOdkd+oe6pcIP6hnhHRp53wqmG
------END PKCS7-----`
-
-var FirefoxAddonRootCert = []byte(`
------BEGIN CERTIFICATE-----
-MIIGYTCCBEmgAwIBAgIBATANBgkqhkiG9w0BAQwFADB9MQswCQYDVQQGEwJVUzEc
-MBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBB
-TU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2Et
-cHJvZHVjdGlvbi1hbW8wHhcNMTUwMzE3MjI1MzU3WhcNMjUwMzE0MjI1MzU3WjB9
-MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0G
-A1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAd
-BgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW8wggIgMA0GCSqGSIb3DQEBAQUA
-A4ICDQAwggIIAoICAQC0u2HXXbrwy36+MPeKf5jgoASMfMNz7mJWBecJgvlTf4hH
-JbLzMPsIUauzI9GEpLfHdZ6wzSyFOb4AM+D1mxAWhuZJ3MDAJOf3B1Rs6QorHrl8
-qqlNtPGqepnpNJcLo7JsSqqE3NUm72MgqIHRgTRsqUs+7LIPGe7262U+N/T0LPYV
-Le4rZ2RDHoaZhYY7a9+49mHOI/g2YFB+9yZjE+XdplT2kBgA4P8db7i7I0tIi4b0
-B0N6y9MhL+CRZJyxdFe2wBykJX14LsheKsM1azHjZO56SKNrW8VAJTLkpRxCmsiT
-r08fnPyDKmaeZ0BtsugicdipcZpXriIGmsZbI12q5yuwjSELdkDV6Uajo2n+2ws5
-uXrP342X71WiWhC/dF5dz1LKtjBdmUkxaQMOP/uhtXEKBrZo1ounDRQx1j7+SkQ4
-BEwjB3SEtr7XDWGOcOIkoJZWPACfBLC3PJCBWjTAyBlud0C5n3Cy9regAAnOIqI1
-t16GU2laRh7elJ7gPRNgQgwLXeZcFxw6wvyiEcmCjOEQ6PM8UQjthOsKlszMhlKw
-vjyOGDoztkqSBy/v+Asx7OW2Q7rlVfKarL0mREZdSMfoy3zTgtMVCM0vhNl6zcvf
-5HNNopoEdg5yuXo2chZ1p1J+q86b0G5yJRMeT2+iOVY2EQ37tHrqUURncCy4uwIB
-A6OB7TCB6jAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAWBgNVHSUBAf8E
-DDAKBggrBgEFBQcDAzCBkgYDVR0jBIGKMIGHoYGBpH8wfTELMAkGA1UEBhMCVVMx
-HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
-QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNh
-LXByb2R1Y3Rpb24tYW1vggEBMB0GA1UdDgQWBBSzvOpYdKvhbngqsqucIx6oYyyX
-tzANBgkqhkiG9w0BAQwFAAOCAgEAaNSRYAaECAePQFyfk12kl8UPLh8hBNidP2H6
-KT6O0vCVBjxmMrwr8Aqz6NL+TgdPmGRPDDLPDpDJTdWzdj7khAjxqWYhutACTew5
-eWEaAzyErbKQl+duKvtThhV2p6F6YHJ2vutu4KIciOMKB8dslIqIQr90IX2Usljq
-8Ttdyf+GhUmazqLtoB0GOuESEqT4unX6X7vSGu1oLV20t7t5eCnMMYD67ZBn0YIU
-/cm/+pan66hHrja+NeDGF8wabJxdqKItCS3p3GN1zUGuJKrLykxqbOp/21byAGog
-Z1amhz6NHUcfE6jki7sM7LHjPostU5ZWs3PEfVVgha9fZUhOrIDsyXEpCWVa3481
-LlAq3GiUMKZ5DVRh9/Nvm4NwrTfB3QkQQJCwfXvO9pwnPKtISYkZUqhEqvXk5nBg
-QCkDSLDjXTx39naBBGIVIqBtKKuVTla9enngdq692xX/CgO6QJVrwpqdGjebj5P8
-5fNZPABzTezG3Uls5Vp+4iIWVAEDkK23cUj3c/HhE+Oo7kxfUeu5Y1ZV3qr61+6t
-ZARKjbu1TuYQHf0fs+GwID8zeLc2zJL7UzcHFwwQ6Nda9OJN4uPAuC/BKaIpxCLL
-26b24/tRam4SJjqpiq20lynhUrmTtt6hbG3E1Hpy3bmkt2DYnuMFwEx2gfXNcnbT
-wNuvFqc=
------END CERTIFICATE-----`)

--- a/sign.go
+++ b/sign.go
@@ -1,0 +1,298 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// SignedData is an opaque data structure for creating signed data payloads
+type SignedData struct {
+	sd                  signedData
+	certs               []*x509.Certificate
+	data, messageDigest []byte
+}
+
+// NewSignedData takes data and initializes a PKCS7 SignedData struct that is
+// ready to be signed via AddSigner.
+func NewSignedData(data []byte) (*SignedData, error) {
+	content, err := asn1.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	ci := contentInfo{
+		ContentType: oidData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
+	}
+	sd := signedData{
+		ContentInfo: ci,
+		Version:     1,
+	}
+	return &SignedData{sd: sd, data: data}, nil
+}
+
+// SignerInfoConfig are optional values to include when adding a signer
+type SignerInfoConfig struct {
+	ExtraSignedAttributes []Attribute
+}
+
+type signedData struct {
+	Version                    int                        `asn1:"default:1"`
+	DigestAlgorithmIdentifiers []pkix.AlgorithmIdentifier `asn1:"set"`
+	ContentInfo                contentInfo
+	Certificates               rawCertificates        `asn1:"optional,tag:0"`
+	CRLs                       []pkix.CertificateList `asn1:"optional,tag:1"`
+	SignerInfos                []signerInfo           `asn1:"set"`
+}
+
+type signerInfo struct {
+	Version                   int `asn1:"default:1"`
+	IssuerAndSerialNumber     issuerAndSerial
+	DigestAlgorithm           pkix.AlgorithmIdentifier
+	AuthenticatedAttributes   []attribute `asn1:"optional,tag:0"`
+	DigestEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedDigest           []byte
+	UnauthenticatedAttributes []attribute `asn1:"optional,tag:1"`
+}
+
+type attribute struct {
+	Type  asn1.ObjectIdentifier
+	Value asn1.RawValue `asn1:"set"`
+}
+
+func marshalAttributes(attrs []attribute) ([]byte, error) {
+	encodedAttributes, err := asn1.Marshal(struct {
+		A []attribute `asn1:"set"`
+	}{A: attrs})
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the leading sequence octets
+	var raw asn1.RawValue
+	asn1.Unmarshal(encodedAttributes, &raw)
+	return raw.Bytes, nil
+}
+
+type rawCertificates struct {
+	Raw asn1.RawContent
+}
+
+type issuerAndSerial struct {
+	IssuerName   asn1.RawValue
+	SerialNumber *big.Int
+}
+
+// AddSigner is a wrapper around AddSignerChain() that adds a signer without any parent.
+func (sd *SignedData) AddSigner(ee *x509.Certificate, pkey crypto.PrivateKey, config SignerInfoConfig) error {
+	var parents []*x509.Certificate
+	return sd.AddSignerChain(ee, pkey, parents, config)
+}
+
+// AddSignerChain signs attributes about the content and adds certificates
+// and signers infos to the Signed Data. The certificate and private
+// of the end-entity signer are used to issue the signature, and any
+// parent of that end-entity that need to be added to the list of
+// certifications can be specified in the parents slice.
+//
+// The signature algorithm used to hash the data is the one of the end-entity
+// certificate.
+//
+// Following RFC 2315, 9.2 SignerInfo type, the distinguished name of
+// the issuer of the end-entity signer is stored in the issuerAndSerialNumber
+// section of the SignedData.SignerInfo, alongside the serial number of
+// the end-entity.
+func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKey, chain []*x509.Certificate, config SignerInfoConfig) error {
+	oidDigestAlg, err := getDigestOIDForSignatureAlgorithm(ee.SignatureAlgorithm)
+	if err != nil {
+		return err
+	}
+	sd.sd.DigestAlgorithmIdentifiers = append(sd.sd.DigestAlgorithmIdentifiers, pkix.AlgorithmIdentifier{Algorithm: oidDigestAlg})
+	hash, err := getHashForOID(oidDigestAlg)
+	if err != nil {
+		return err
+	}
+	h := hash.New()
+	h.Write(sd.data)
+	sd.messageDigest = h.Sum(nil)
+	oidEncryptionAlg, err := getOIDForEncryptionAlgorithm(pkey, oidDigestAlg)
+	if err != nil {
+		return err
+	}
+	attrs := &attributes{}
+	attrs.Add(oidAttributeContentType, sd.sd.ContentInfo.ContentType)
+	attrs.Add(oidAttributeMessageDigest, sd.messageDigest)
+	attrs.Add(oidAttributeSigningTime, time.Now())
+	for _, attr := range config.ExtraSignedAttributes {
+		attrs.Add(attr.Type, attr.Value)
+	}
+	finalAttrs, err := attrs.ForMarshalling()
+	if err != nil {
+		return err
+	}
+	signature, err := signAttributes(finalAttrs, pkey, hash)
+	if err != nil {
+		return err
+	}
+	var ias issuerAndSerial
+	ias.SerialNumber = ee.SerialNumber
+	if len(chain) == 0 {
+		// no parent, the issue is the end-entity cert itself
+		ias.IssuerName = asn1.RawValue{FullBytes: ee.RawIssuer}
+	} else {
+		err = verifyPartialChain(ee, chain)
+		if err != nil {
+			return err
+		}
+		// the first parent is the issuer
+		ias.IssuerName = asn1.RawValue{FullBytes: chain[0].RawSubject}
+	}
+	signer := signerInfo{
+		AuthenticatedAttributes:   finalAttrs,
+		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: oidDigestAlg},
+		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: oidEncryptionAlg},
+		IssuerAndSerialNumber:     ias,
+		EncryptedDigest:           signature,
+		Version:                   1,
+	}
+	// create signature of signed attributes
+	sd.certs = append(sd.certs, ee)
+	sd.certs = append(sd.certs, chain...)
+	sd.sd.SignerInfos = append(sd.sd.SignerInfos, signer)
+	return nil
+}
+
+// AddCertificate adds the certificate to the payload. Useful for parent certificates
+func (sd *SignedData) AddCertificate(cert *x509.Certificate) {
+	sd.certs = append(sd.certs, cert)
+}
+
+// Detach removes content from the signed data struct to make it a detached signature.
+// This must be called right before Finish()
+func (sd *SignedData) Detach() {
+	sd.sd.ContentInfo = contentInfo{ContentType: oidSignedData}
+}
+
+// Finish marshals the content and its signers
+func (sd *SignedData) Finish() ([]byte, error) {
+	sd.sd.Certificates = marshalCertificates(sd.certs)
+	inner, err := asn1.Marshal(sd.sd)
+	if err != nil {
+		return nil, err
+	}
+	outer := contentInfo{
+		ContentType: oidSignedData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: inner, IsCompound: true},
+	}
+	return asn1.Marshal(outer)
+}
+
+// verifyPartialChain checks that a given cert is issued by the first parent in the list,
+// then continue down the path. It doesn't require the last parent to be a root CA,
+// or to be trusted in any truststore. It simply verifies that the chain provided, albeit
+// partial, makes sense.
+func verifyPartialChain(cert *x509.Certificate, parents []*x509.Certificate) error {
+	if len(parents) == 0 {
+		return fmt.Errorf("pkcs7: zero parents provided to verify the signature of certificate %q", cert.Subject.CommonName)
+	}
+	err := cert.CheckSignatureFrom(parents[0])
+	if err != nil {
+		return fmt.Errorf("pkcs7: certificate signature from parent is invalid: %v", err)
+	}
+	if len(parents) == 1 {
+		// there is no more parent to check, return
+		return nil
+	}
+	return verifyPartialChain(parents[0], parents[1:])
+}
+
+func cert2issuerAndSerial(cert *x509.Certificate) (issuerAndSerial, error) {
+	var ias issuerAndSerial
+	// The issuer RDNSequence has to match exactly the sequence in the certificate
+	// We cannot use cert.Issuer.ToRDNSequence() here since it mangles the sequence
+	ias.IssuerName = asn1.RawValue{FullBytes: cert.RawIssuer}
+	ias.SerialNumber = cert.SerialNumber
+
+	return ias, nil
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int // fields must be exported for ASN.1 marshalling
+}
+
+// signs the DER encoded form of the attributes with the private key
+func signAttributes(attrs []attribute, pkey crypto.PrivateKey, digestAlg crypto.Hash) ([]byte, error) {
+	attrBytes, err := marshalAttributes(attrs)
+	if err != nil {
+		return nil, err
+	}
+	h := digestAlg.New()
+	h.Write(attrBytes)
+	hash := h.Sum(nil)
+	switch pkey.(type) {
+	case *rsa.PrivateKey:
+		return rsa.SignPKCS1v15(rand.Reader, pkey.(*rsa.PrivateKey), digestAlg, hash)
+	case *ecdsa.PrivateKey:
+		r, s, err := ecdsa.Sign(rand.Reader, pkey.(*ecdsa.PrivateKey), hash)
+		if err != nil {
+			return nil, fmt.Errorf("pkcs7: failed to sign attributes: %v", err)
+		}
+		return asn1.Marshal(ecdsaSignature{R: r, S: s})
+	}
+	return nil, fmt.Errorf("pkcs7: unsupported signing key type %T", pkey)
+}
+
+// concats and wraps the certificates in the RawValue structure
+func marshalCertificates(certs []*x509.Certificate) rawCertificates {
+	var buf bytes.Buffer
+	for _, cert := range certs {
+		buf.Write(cert.Raw)
+	}
+	rawCerts, _ := marshalCertificateBytes(buf.Bytes())
+	return rawCerts
+}
+
+// Even though, the tag & length are stripped out during marshalling the
+// RawContent, we have to encode it into the RawContent. If its missing,
+// then `asn1.Marshal()` will strip out the certificate wrapper instead.
+func marshalCertificateBytes(certs []byte) (rawCertificates, error) {
+	var val = asn1.RawValue{Bytes: certs, Class: 2, Tag: 0, IsCompound: true}
+	b, err := asn1.Marshal(val)
+	if err != nil {
+		return rawCertificates{}, err
+	}
+	return rawCertificates{Raw: b}, nil
+}
+
+// DegenerateCertificate creates a signed data structure containing only the
+// provided certificate or certificate chain.
+func DegenerateCertificate(cert []byte) ([]byte, error) {
+	rawCert, err := marshalCertificateBytes(cert)
+	if err != nil {
+		return nil, err
+	}
+	emptyContent := contentInfo{ContentType: oidData}
+	sd := signedData{
+		Version:      1,
+		ContentInfo:  emptyContent,
+		Certificates: rawCert,
+		CRLs:         []pkix.CertificateList{},
+	}
+	content, err := asn1.Marshal(sd)
+	if err != nil {
+		return nil, err
+	}
+	signedContent := contentInfo{
+		ContentType: oidSignedData,
+		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
+	}
+	return asn1.Marshal(signedContent)
+}

--- a/sign_test.go
+++ b/sign_test.go
@@ -1,0 +1,276 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestSign(t *testing.T) {
+	content := []byte("Hello World")
+	sigalgs := []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
+		x509.SHA256WithRSA,
+		x509.SHA512WithRSA,
+		x509.ECDSAWithSHA1,
+		x509.ECDSAWithSHA256,
+		x509.ECDSAWithSHA384,
+		x509.ECDSAWithSHA512,
+	}
+	for _, sigalgroot := range sigalgs {
+		rootCert, err := createTestCertificateByIssuer("PKCS7 Test Root CA", nil, sigalgroot, true)
+		if err != nil {
+			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
+		}
+		truststore := x509.NewCertPool()
+		truststore.AddCert(rootCert.Certificate)
+		for _, sigalginter := range sigalgs {
+			interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate Cert", rootCert, sigalginter, true)
+			if err != nil {
+				t.Fatalf("test %s/%s: cannot generate intermediate cert: %s", sigalgroot, sigalginter, err)
+			}
+			var parents []*x509.Certificate
+			parents = append(parents, interCert.Certificate)
+			for _, sigalgsigner := range sigalgs {
+				signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", interCert, sigalgsigner, false)
+				if err != nil {
+					t.Fatalf("test %s/%s/%s: cannot generate signer cert: %s", sigalgroot, sigalginter, sigalgsigner, err)
+				}
+				for _, testDetach := range []bool{false, true} {
+					log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalginter, sigalgsigner, testDetach)
+					toBeSigned, err := NewSignedData(content)
+					if err != nil {
+						t.Fatalf("test %s/%s/%s: cannot initialize signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
+					}
+					if err := toBeSigned.AddSignerChain(signerCert.Certificate, *signerCert.PrivateKey, parents, SignerInfoConfig{}); err != nil {
+						t.Fatalf("test %s/%s/%s: cannot add signer: %s", sigalgroot, sigalginter, sigalgsigner, err)
+					}
+					if testDetach {
+						toBeSigned.Detach()
+					}
+					signed, err := toBeSigned.Finish()
+					if err != nil {
+						t.Fatalf("test %s/%s/%s: cannot finish signing data: %s", sigalgroot, sigalginter, sigalgsigner, err)
+					}
+					pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
+					p7, err := Parse(signed)
+					if err != nil {
+						t.Fatalf("test %s/%s/%s: cannot parse signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
+					}
+					if testDetach {
+						p7.Content = content
+					}
+					if !bytes.Equal(content, p7.Content) {
+						t.Errorf("test %s/%s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalginter, sigalgsigner, content, p7.Content)
+					}
+					if err := p7.VerifyWithChain(truststore); err != nil {
+						t.Errorf("test %s/%s/%s: cannot verify signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSignAndVerifyWithOpenSSL(t *testing.T) {
+	content := []byte("Hello World")
+	// write the content to a temp file
+	tmpContentFile, err := ioutil.TempFile("", "TestSignAndVerifyWithOpenSSL_content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
+
+	sigalgs := []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
+		x509.SHA256WithRSA,
+		x509.SHA512WithRSA,
+		x509.ECDSAWithSHA1,
+		x509.ECDSAWithSHA256,
+		x509.ECDSAWithSHA384,
+		x509.ECDSAWithSHA512,
+	}
+	for i, sigalg := range sigalgs {
+		log.Printf("test case %d sigalg %s\n", i, sigalg)
+		rootCert, err := createTestCertificateByIssuer("PKCS7 Test Root CA", nil, sigalg, true)
+		if err != nil {
+			t.Fatalf("test case %d sigalg %s: cannot generate root cert: %s", i, sigalg, err)
+		}
+		// write the root cert to a temp file
+		tmpRootCertFile, err := ioutil.TempFile("", "TestSignAndVerifyWithOpenSSL_root")
+		if err != nil {
+			t.Fatal(err)
+		}
+		fd, err := os.OpenFile(tmpRootCertFile.Name(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Certificate.Raw})
+		fd.Close()
+
+		interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate CA", rootCert, sigalg, true)
+		if err != nil {
+			t.Fatalf("test case %d sigalg %s: cannot generate intermediate cert: %s", i, sigalg, err)
+		}
+		var intermediates []*x509.Certificate
+		intermediates = append(intermediates, interCert.Certificate)
+		signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", interCert, sigalg, false)
+		if err != nil {
+			t.Fatalf("test case %d sigalg %s: cannot generate signer cert: %s", i, sigalg, err)
+		}
+
+		// write the signer cert to a temp file
+		tmpSignerCertFile, err := ioutil.TempFile("", "TestSignAndVerifyWithOpenSSL_signer")
+		if err != nil {
+			t.Fatal(err)
+		}
+		fd, err = os.OpenFile(tmpSignerCertFile.Name(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: signerCert.Certificate.Raw})
+		fd.Close()
+
+		toBeSigned, err := NewSignedData(content)
+		if err != nil {
+			t.Fatalf("test case %d sigalg %s: cannot initialize signed data: %s", i, sigalg, err)
+		}
+		if err := toBeSigned.AddSignerChain(signerCert.Certificate, *signerCert.PrivateKey, intermediates, SignerInfoConfig{}); err != nil {
+			t.Fatalf("Cannot add signer: %s", err)
+		}
+		toBeSigned.Detach()
+		signed, err := toBeSigned.Finish()
+		if err != nil {
+			t.Fatalf("test case %d sigalg %s: cannot finish signing data: %s", i, sigalg, err)
+		}
+
+		// write the signature to a temp file
+		tmpSignatureFile, err := ioutil.TempFile("", "TestSignAndVerifyWithOpenSSL_signature")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ioutil.WriteFile(tmpSignatureFile.Name(), pem.EncodeToMemory(&pem.Block{Type: "PKCS7", Bytes: signed}), 0755)
+
+		// call openssl to verify the signature on the content using the root
+		opensslCMD := exec.Command("openssl", "smime", "-verify",
+			"-in", tmpSignatureFile.Name(), "-inform", "PEM",
+			"-content", tmpContentFile.Name(),
+			"-CAfile", tmpRootCertFile.Name())
+		out, err := opensslCMD.CombinedOutput()
+		if err != nil {
+			t.Fatalf("test case %d sigalg %s: openssl command failed with %s: %s", i, sigalg, err, out)
+		}
+		os.Remove(tmpSignatureFile.Name()) // clean up
+		os.Remove(tmpRootCertFile.Name())  // clean up
+	}
+	os.Remove(tmpContentFile.Name()) // clean up
+}
+
+func ExampleSignedData() {
+	// generate a signing cert or load a key pair
+	cert, err := createTestCertificate(x509.SHA256WithRSA)
+	if err != nil {
+		fmt.Printf("Cannot create test certificates: %s", err)
+	}
+
+	// Initialize a SignedData struct with content to be signed
+	signedData, err := NewSignedData([]byte("Example data to be signed"))
+	if err != nil {
+		fmt.Printf("Cannot initialize signed data: %s", err)
+	}
+
+	// Add the signing cert and private key
+	if err := signedData.AddSigner(cert.Certificate, cert.PrivateKey, SignerInfoConfig{}); err != nil {
+		fmt.Printf("Cannot add signer: %s", err)
+	}
+
+	// Call Detach() is you want to remove content from the signature
+	// and generate an S/MIME detached signature
+	signedData.Detach()
+
+	// Finish() to obtain the signature bytes
+	detachedSignature, err := signedData.Finish()
+	if err != nil {
+		fmt.Printf("Cannot finish signing data: %s", err)
+	}
+	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
+}
+
+func TestUnmarshalSignedAttribute(t *testing.T) {
+	cert, err := createTestCertificate(x509.SHA512WithRSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("Hello World")
+	toBeSigned, err := NewSignedData(content)
+	if err != nil {
+		t.Fatalf("Cannot initialize signed data: %s", err)
+	}
+	oidTest := asn1.ObjectIdentifier{2, 3, 4, 5, 6, 7}
+	testValue := "TestValue"
+	if err := toBeSigned.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{
+		ExtraSignedAttributes: []Attribute{Attribute{Type: oidTest, Value: testValue}},
+	}); err != nil {
+		t.Fatalf("Cannot add signer: %s", err)
+	}
+	signed, err := toBeSigned.Finish()
+	if err != nil {
+		t.Fatalf("Cannot finish signing data: %s", err)
+	}
+	p7, err := Parse(signed)
+	if err != nil {
+		t.Fatalf("Cannot parse signed data: %v", err)
+	}
+	var actual string
+	err = p7.UnmarshalSignedAttribute(oidTest, &actual)
+	if err != nil {
+		t.Fatalf("Cannot unmarshal test value: %s", err)
+	}
+	if testValue != actual {
+		t.Errorf("Attribute does not match test value\n\tExpected: %s\n\tActual: %s", testValue, actual)
+	}
+}
+
+func TestDegenerateCertificate(t *testing.T) {
+	cert, err := createTestCertificate(x509.SHA1WithRSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deg, err := DegenerateCertificate(cert.Certificate.Raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testOpenSSLParse(t, deg)
+	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: deg})
+}
+
+// writes the cert to a temporary file and tests that openssl can read it.
+func testOpenSSLParse(t *testing.T, certBytes []byte) {
+	tmpCertFile, err := ioutil.TempFile("", "testCertificate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpCertFile.Name()) // clean up
+
+	if _, err := tmpCertFile.Write(certBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	opensslCMD := exec.Command("openssl", "pkcs7", "-inform", "der", "-in", tmpCertFile.Name())
+	_, err = opensslCMD.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tmpCertFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/verify.go
+++ b/verify.go
@@ -1,0 +1,255 @@
+package pkcs7
+
+import (
+	"crypto/subtle"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Verify is a wrapper around VerifyWithChain() that initializes an empty
+// trust store, effectively disabling certificate verification when validating
+// a signature.
+func (p7 *PKCS7) Verify() (err error) {
+	return p7.VerifyWithChain(nil)
+}
+
+// VerifyWithChain checks the signatures of a PKCS7 object.
+// If truststore is not nil, it also verifies the chain of trust of the end-entity
+// signer cert to one of the root in the truststore.
+func (p7 *PKCS7) VerifyWithChain(truststore *x509.CertPool) (err error) {
+	if len(p7.Signers) == 0 {
+		return errors.New("pkcs7: Message has no signers")
+	}
+	for _, signer := range p7.Signers {
+		if err := verifySignature(p7, signer, truststore); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (err error) {
+	signedData := p7.Content
+	ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
+	if ee == nil {
+		return errors.New("pkcs7: No certificate for signer")
+	}
+	signingTime := time.Now().UTC()
+	if len(signer.AuthenticatedAttributes) > 0 {
+		// TODO(fullsailor): First check the content type match
+		var digest []byte
+		err := unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeMessageDigest, &digest)
+		if err != nil {
+			return err
+		}
+		hash, err := getHashForOID(signer.DigestAlgorithm.Algorithm)
+		if err != nil {
+			return err
+		}
+		h := hash.New()
+		h.Write(p7.Content)
+		computed := h.Sum(nil)
+		if subtle.ConstantTimeCompare(digest, computed) != 1 {
+			return &MessageDigestMismatchError{
+				ExpectedDigest: digest,
+				ActualDigest:   computed,
+			}
+		}
+		signedData, err = marshalAttributes(signer.AuthenticatedAttributes)
+		if err != nil {
+			return err
+		}
+		err = unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeSigningTime, &signingTime)
+		if err == nil {
+			// signing time found, performing validity check
+			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
+				return fmt.Errorf("pkcs7: signing time %q it outside of certificate validity %q to %q",
+					signingTime.Format(time.RFC3339),
+					ee.NotBefore.Format(time.RFC3339),
+					ee.NotBefore.Format(time.RFC3339))
+			}
+		}
+	}
+	if truststore != nil {
+		_, err = verifyCertChain(ee, p7.Certificates, truststore, signingTime)
+		if err != nil {
+			return err
+		}
+	}
+	sigalg, err := getSignatureAlgorithm(signer.DigestEncryptionAlgorithm, signer.DigestAlgorithm)
+	if err != nil {
+		return err
+	}
+	return ee.CheckSignature(sigalg, signedData, signer.EncryptedDigest)
+}
+
+// GetOnlySigner returns an x509.Certificate for the first signer of the signed
+// data payload. If there are more or less than one signer, nil is returned
+func (p7 *PKCS7) GetOnlySigner() *x509.Certificate {
+	if len(p7.Signers) != 1 {
+		return nil
+	}
+	signer := p7.Signers[0]
+	return getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
+}
+
+// UnmarshalSignedAttribute decodes a single attribute from the signer info
+func (p7 *PKCS7) UnmarshalSignedAttribute(attributeType asn1.ObjectIdentifier, out interface{}) error {
+	sd, ok := p7.raw.(signedData)
+	if !ok {
+		return errors.New("pkcs7: payload is not signedData content")
+	}
+	if len(sd.SignerInfos) < 1 {
+		return errors.New("pkcs7: payload has no signers")
+	}
+	attributes := sd.SignerInfos[0].AuthenticatedAttributes
+	return unmarshalAttribute(attributes, attributeType, out)
+}
+
+func parseSignedData(data []byte) (*PKCS7, error) {
+	var sd signedData
+	asn1.Unmarshal(data, &sd)
+	certs, err := sd.Certificates.Parse()
+	if err != nil {
+		return nil, err
+	}
+	// fmt.Printf("--> Signed Data Version %d\n", sd.Version)
+
+	var compound asn1.RawValue
+	var content unsignedData
+
+	// The Content.Bytes maybe empty on PKI responses.
+	if len(sd.ContentInfo.Content.Bytes) > 0 {
+		if _, err := asn1.Unmarshal(sd.ContentInfo.Content.Bytes, &compound); err != nil {
+			return nil, err
+		}
+	}
+	// Compound octet string
+	if compound.IsCompound {
+		if _, err = asn1.Unmarshal(compound.Bytes, &content); err != nil {
+			return nil, err
+		}
+	} else {
+		// assuming this is tag 04
+		content = compound.Bytes
+	}
+	return &PKCS7{
+		Content:      content,
+		Certificates: certs,
+		CRLs:         sd.CRLs,
+		Signers:      sd.SignerInfos,
+		raw:          sd}, nil
+}
+
+// verifyCertChain takes an end-entity certs, a list of potential intermediates and a
+// truststore, and built all potential chains between the EE and a trusted root.
+//
+// When verifying chains that may have expired, currentTime can be set to a past date
+// to allow the verification to pass. If unset, currentTime is set to the current UTC time.
+func verifyCertChain(ee *x509.Certificate, certs []*x509.Certificate, truststore *x509.CertPool, currentTime time.Time) (chains [][]*x509.Certificate, err error) {
+	intermediates := x509.NewCertPool()
+	for _, intermediate := range certs {
+		intermediates.AddCert(intermediate)
+	}
+	verifyOptions := x509.VerifyOptions{
+		Roots:         truststore,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		CurrentTime:   currentTime,
+	}
+	chains, err = ee.Verify(verifyOptions)
+	if err != nil {
+		return chains, fmt.Errorf("pkcs7: failed to verify certificate chain: %v", err)
+	}
+	return
+}
+
+// MessageDigestMismatchError is returned when the signer data digest does not
+// match the computed digest for the contained content
+type MessageDigestMismatchError struct {
+	ExpectedDigest []byte
+	ActualDigest   []byte
+}
+
+func (err *MessageDigestMismatchError) Error() string {
+	return fmt.Sprintf("pkcs7: Message digest mismatch\n\tExpected: %X\n\tActual  : %X", err.ExpectedDigest, err.ActualDigest)
+}
+
+func getSignatureAlgorithm(digestEncryption, digest pkix.AlgorithmIdentifier) (x509.SignatureAlgorithm, error) {
+	switch {
+	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA1):
+		return x509.ECDSAWithSHA1, nil
+	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA256):
+		return x509.ECDSAWithSHA256, nil
+	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA384):
+		return x509.ECDSAWithSHA384, nil
+	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA512):
+		return x509.ECDSAWithSHA512, nil
+	case digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSA):
+		switch {
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA1):
+			return x509.SHA1WithRSA, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA256):
+			return x509.SHA256WithRSA, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA384):
+			return x509.SHA384WithRSA, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA512):
+			return x509.SHA512WithRSA, nil
+		default:
+			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
+				digest.Algorithm.String(), digestEncryption.Algorithm.String())
+		}
+	case digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmDSA):
+		switch {
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA1):
+			return x509.DSAWithSHA1, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA256):
+			return x509.DSAWithSHA256, nil
+		default:
+			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
+				digest.Algorithm.String(), digestEncryption.Algorithm.String())
+		}
+	case digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP256),
+		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP384),
+		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP521):
+		switch {
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA1):
+			return x509.ECDSAWithSHA1, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA256):
+			return x509.ECDSAWithSHA256, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA384):
+			return x509.ECDSAWithSHA384, nil
+		case digest.Algorithm.Equal(oidDigestAlgorithmSHA512):
+			return x509.ECDSAWithSHA512, nil
+		default:
+			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
+				digest.Algorithm.String(), digestEncryption.Algorithm.String())
+		}
+	default:
+		return -1, fmt.Errorf("pkcs7: unsupported encryption algorithm %q",
+			digestEncryption.Algorithm.String())
+	}
+}
+
+func getCertFromCertsByIssuerAndSerial(certs []*x509.Certificate, ias issuerAndSerial) *x509.Certificate {
+	for _, cert := range certs {
+		if isCertMatchForIssuerAndSerial(cert, ias) {
+			return cert
+		}
+	}
+	return nil
+}
+
+func unmarshalAttribute(attrs []attribute, attributeType asn1.ObjectIdentifier, out interface{}) error {
+	for _, attr := range attrs {
+		if attr.Type.Equal(attributeType) {
+			_, err := asn1.Unmarshal(attr.Value.Bytes, out)
+			return err
+		}
+	}
+	return errors.New("pkcs7: attribute type not in attributes")
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,583 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestVerify(t *testing.T) {
+	fixture := UnmarshalTestFixture(SignedTestFixture)
+	p7, err := Parse(fixture.Input)
+	if err != nil {
+		t.Errorf("Parse encountered unexpected error: %v", err)
+	}
+
+	if err := p7.Verify(); err != nil {
+		t.Errorf("Verify failed with error: %v", err)
+	}
+	expected := []byte("We the People")
+	if !bytes.Equal(p7.Content, expected) {
+		t.Errorf("Signed content does not match.\n\tExpected:%s\n\tActual:%s", expected, p7.Content)
+
+	}
+}
+
+var SignedTestFixture = `
+-----BEGIN PKCS7-----
+MIIDVgYJKoZIhvcNAQcCoIIDRzCCA0MCAQExCTAHBgUrDgMCGjAcBgkqhkiG9w0B
+BwGgDwQNV2UgdGhlIFBlb3BsZaCCAdkwggHVMIIBQKADAgECAgRpuDctMAsGCSqG
+SIb3DQEBCzApMRAwDgYDVQQKEwdBY21lIENvMRUwEwYDVQQDEwxFZGRhcmQgU3Rh
+cmswHhcNMTUwNTA2MDQyNDQ4WhcNMTYwNTA2MDQyNDQ4WjAlMRAwDgYDVQQKEwdB
+Y21lIENvMREwDwYDVQQDEwhKb24gU25vdzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw
+gYkCgYEAqr+tTF4mZP5rMwlXp1y+crRtFpuLXF1zvBZiYMfIvAHwo1ta8E1IcyEP
+J1jIiKMcwbzeo6kAmZzIJRCTezq9jwXUsKbQTvcfOH9HmjUmXBRWFXZYoQs/OaaF
+a45deHmwEeMQkuSWEtYiVKKZXtJOtflKIT3MryJEDiiItMkdybUCAwEAAaMSMBAw
+DgYDVR0PAQH/BAQDAgCgMAsGCSqGSIb3DQEBCwOBgQDK1EweZWRL+f7Z+J0kVzY8
+zXptcBaV4Lf5wGZJLJVUgp33bpLNpT3yadS++XQJ+cvtW3wADQzBSTMduyOF8Zf+
+L7TjjrQ2+F2HbNbKUhBQKudxTfv9dJHdKbD+ngCCdQJYkIy2YexsoNG0C8nQkggy
+axZd/J69xDVx6pui3Sj8sDGCATYwggEyAgEBMDEwKTEQMA4GA1UEChMHQWNtZSBD
+bzEVMBMGA1UEAxMMRWRkYXJkIFN0YXJrAgRpuDctMAcGBSsOAwIaoGEwGAYJKoZI
+hvcNAQkDMQsGCSqGSIb3DQEHATAgBgkqhkiG9w0BCQUxExcRMTUwNTA2MDAyNDQ4
+LTA0MDAwIwYJKoZIhvcNAQkEMRYEFG9D7gcTh9zfKiYNJ1lgB0yTh4sZMAsGCSqG
+SIb3DQEBAQSBgFF3sGDU9PtXty/QMtpcFa35vvIOqmWQAIZt93XAskQOnBq4OloX
+iL9Ct7t1m4pzjRm0o9nDkbaSLZe7HKASHdCqijroScGlI8M+alJ8drHSFv6ZIjnM
+FIwIf0B2Lko6nh9/6mUXq7tbbIHa3Gd1JUVire/QFFtmgRXMbXYk8SIS
+-----END PKCS7-----
+-----BEGIN CERTIFICATE-----
+MIIB1TCCAUCgAwIBAgIEabg3LTALBgkqhkiG9w0BAQswKTEQMA4GA1UEChMHQWNt
+ZSBDbzEVMBMGA1UEAxMMRWRkYXJkIFN0YXJrMB4XDTE1MDUwNjA0MjQ0OFoXDTE2
+MDUwNjA0MjQ0OFowJTEQMA4GA1UEChMHQWNtZSBDbzERMA8GA1UEAxMISm9uIFNu
+b3cwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKq/rUxeJmT+azMJV6dcvnK0
+bRabi1xdc7wWYmDHyLwB8KNbWvBNSHMhDydYyIijHMG83qOpAJmcyCUQk3s6vY8F
+1LCm0E73Hzh/R5o1JlwUVhV2WKELPzmmhWuOXXh5sBHjEJLklhLWIlSimV7STrX5
+SiE9zK8iRA4oiLTJHcm1AgMBAAGjEjAQMA4GA1UdDwEB/wQEAwIAoDALBgkqhkiG
+9w0BAQsDgYEAytRMHmVkS/n+2fidJFc2PM16bXAWleC3+cBmSSyVVIKd926SzaU9
+8mnUvvl0CfnL7Vt8AA0MwUkzHbsjhfGX/i+04460Nvhdh2zWylIQUCrncU37/XSR
+3Smw/p4AgnUCWJCMtmHsbKDRtAvJ0JIIMmsWXfyevcQ1ceqbot0o/LA=
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+MIICXgIBAAKBgQCqv61MXiZk/mszCVenXL5ytG0Wm4tcXXO8FmJgx8i8AfCjW1rw
+TUhzIQ8nWMiIoxzBvN6jqQCZnMglEJN7Or2PBdSwptBO9x84f0eaNSZcFFYVdlih
+Cz85poVrjl14ebAR4xCS5JYS1iJUople0k61+UohPcyvIkQOKIi0yR3JtQIDAQAB
+AoGBAIPLCR9N+IKxodq11lNXEaUFwMHXc1zqwP8no+2hpz3+nVfplqqubEJ4/PJY
+5AgbJoIfnxVhyBXJXu7E+aD/OPneKZrgp58YvHKgGvvPyJg2gpC/1Fh0vQB0HNpI
+1ZzIZUl8ZTUtVgtnCBUOh5JGI4bFokAqrT//Uvcfd+idgxqBAkEA1ZbP/Kseld14
+qbWmgmU5GCVxsZRxgR1j4lG3UVjH36KXMtRTm1atAam1uw3OEGa6Y3ANjpU52FaB
+Hep5rkk4FQJBAMynMo1L1uiN5GP+KYLEF5kKRxK+FLjXR0ywnMh+gpGcZDcOae+J
++t1gLoWBIESH/Xt639T7smuSfrZSA9V0EyECQA8cvZiWDvLxmaEAXkipmtGPjKzQ
+4PsOtkuEFqFl07aKDYKmLUg3aMROWrJidqsIabWxbvQgsNgSvs38EiH3wkUCQQCg
+ndxb7piVXb9RBwm3OoU2tE1BlXMX+sVXmAkEhd2dwDsaxrI3sHf1xGXem5AimQRF
+JBOFyaCnMotGNioSHY5hAkEAxyXcNixQ2RpLXJTQZtwnbk0XDcbgB+fBgXnv/4f3
+BCvcu85DqJeJyQv44Oe1qsXEX9BfcQIOVaoep35RPlKi9g==
+-----END PRIVATE KEY-----`
+
+func TestVerifyEC2(t *testing.T) {
+	fixture := UnmarshalTestFixture(EC2IdentityDocumentFixture)
+	p7, err := Parse(fixture.Input)
+	if err != nil {
+		t.Errorf("Parse encountered unexpected error: %v", err)
+	}
+	p7.Certificates = []*x509.Certificate{fixture.Certificate}
+	if err := p7.Verify(); err != nil {
+		t.Errorf("Verify failed with error: %v", err)
+	}
+}
+
+var EC2IdentityDocumentFixture = `
+-----BEGIN PKCS7-----
+MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqGSIb3DQEHAaCA
+JIAEggGmewogICJwcml2YXRlSXAiIDogIjE3Mi4zMC4wLjI1MiIsCiAgImRldnBh
+eVByb2R1Y3RDb2RlcyIgOiBudWxsLAogICJhdmFpbGFiaWxpdHlab25lIiA6ICJ1
+cy1lYXN0LTFhIiwKICAidmVyc2lvbiIgOiAiMjAxMC0wOC0zMSIsCiAgImluc3Rh
+bmNlSWQiIDogImktZjc5ZmU1NmMiLAogICJiaWxsaW5nUHJvZHVjdHMiIDogbnVs
+bCwKICAiaW5zdGFuY2VUeXBlIiA6ICJ0Mi5taWNybyIsCiAgImFjY291bnRJZCIg
+OiAiMTIxNjU5MDE0MzM0IiwKICAiaW1hZ2VJZCIgOiAiYW1pLWZjZTNjNjk2IiwK
+ICAicGVuZGluZ1RpbWUiIDogIjIwMTYtMDQtMDhUMDM6MDE6MzhaIiwKICAiYXJj
+aGl0ZWN0dXJlIiA6ICJ4ODZfNjQiLAogICJrZXJuZWxJZCIgOiBudWxsLAogICJy
+YW1kaXNrSWQiIDogbnVsbCwKICAicmVnaW9uIiA6ICJ1cy1lYXN0LTEiCn0AAAAA
+AAAxggEYMIIBFAIBATBpMFwxCzAJBgNVBAYTAlVTMRkwFwYDVQQIExBXYXNoaW5n
+dG9uIFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYDVQQKExdBbWF6b24gV2Vi
+IFNlcnZpY2VzIExMQwIJAJa6SNnlXhpnMAkGBSsOAwIaBQCgXTAYBgkqhkiG9w0B
+CQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0xNjA0MDgwMzAxNDRaMCMG
+CSqGSIb3DQEJBDEWBBTuUc28eBXmImAautC+wOjqcFCBVjAJBgcqhkjOOAQDBC8w
+LQIVAKA54NxGHWWCz5InboDmY/GHs33nAhQ6O/ZI86NwjA9Vz3RNMUJrUPU5tAAA
+AAAAAA==
+-----END PKCS7-----
+-----BEGIN CERTIFICATE-----
+MIIC7TCCAq0CCQCWukjZ5V4aZzAJBgcqhkjOOAQDMFwxCzAJBgNVBAYTAlVTMRkw
+FwYDVQQIExBXYXNoaW5ndG9uIFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYD
+VQQKExdBbWF6b24gV2ViIFNlcnZpY2VzIExMQzAeFw0xMjAxMDUxMjU2MTJaFw0z
+ODAxMDUxMjU2MTJaMFwxCzAJBgNVBAYTAlVTMRkwFwYDVQQIExBXYXNoaW5ndG9u
+IFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYDVQQKExdBbWF6b24gV2ViIFNl
+cnZpY2VzIExMQzCCAbcwggEsBgcqhkjOOAQBMIIBHwKBgQCjkvcS2bb1VQ4yt/5e
+ih5OO6kK/n1Lzllr7D8ZwtQP8fOEpp5E2ng+D6Ud1Z1gYipr58Kj3nssSNpI6bX3
+VyIQzK7wLclnd/YozqNNmgIyZecN7EglK9ITHJLP+x8FtUpt3QbyYXJdmVMegN6P
+hviYt5JH/nYl4hh3Pa1HJdskgQIVALVJ3ER11+Ko4tP6nwvHwh6+ERYRAoGBAI1j
+k+tkqMVHuAFcvAGKocTgsjJem6/5qomzJuKDmbJNu9Qxw3rAotXau8Qe+MBcJl/U
+hhy1KHVpCGl9fueQ2s6IL0CaO/buycU1CiYQk40KNHCcHfNiZbdlx1E9rpUp7bnF
+lRa2v1ntMX3caRVDdbtPEWmdxSCYsYFDk4mZrOLBA4GEAAKBgEbmeve5f8LIE/Gf
+MNmP9CM5eovQOGx5ho8WqD+aTebs+k2tn92BBPqeZqpWRa5P/+jrdKml1qx4llHW
+MXrs3IgIb6+hUIB+S8dz8/mmO0bpr76RoZVCXYab2CZedFut7qc3WUH9+EUAH5mw
+vSeDCOUMYQR7R9LINYwouHIziqQYMAkGByqGSM44BAMDLwAwLAIUWXBlk40xTwSw
+7HX32MxXYruse9ACFBNGmdX2ZBrVNGrN9N2f6ROk0k9K
+-----END CERTIFICATE-----`
+
+func TestVerifyAppStore(t *testing.T) {
+	fixture := UnmarshalTestFixture(AppStoreReceiptFixture)
+	p7, err := Parse(fixture.Input)
+	if err != nil {
+		t.Errorf("Parse encountered unexpected error: %v", err)
+	}
+	if err := p7.Verify(); err != nil {
+		t.Errorf("Verify failed with error: %v", err)
+	}
+}
+
+var AppStoreReceiptFixture = `
+-----BEGIN PKCS7-----
+MIITtgYJKoZIhvcNAQcCoIITpzCCE6MCAQExCzAJBgUrDgMCGgUAMIIDVwYJKoZI
+hvcNAQcBoIIDSASCA0QxggNAMAoCAQgCAQEEAhYAMAoCARQCAQEEAgwAMAsCAQEC
+AQEEAwIBADALAgEDAgEBBAMMATEwCwIBCwIBAQQDAgEAMAsCAQ8CAQEEAwIBADAL
+AgEQAgEBBAMCAQAwCwIBGQIBAQQDAgEDMAwCAQoCAQEEBBYCNCswDAIBDgIBAQQE
+AgIAjTANAgENAgEBBAUCAwFgvTANAgETAgEBBAUMAzEuMDAOAgEJAgEBBAYCBFAy
+NDcwGAIBAgIBAQQQDA5jb20uemhpaHUudGVzdDAYAgEEAgECBBCS+ZODNMHwT1Nz
+gWYDXyWZMBsCAQACAQEEEwwRUHJvZHVjdGlvblNhbmRib3gwHAIBBQIBAQQU4nRh
+YCEZx70Flzv7hvJRjJZckYIwHgIBDAIBAQQWFhQyMDE2LTA3LTIzVDA2OjIxOjEx
+WjAeAgESAgEBBBYWFDIwMTMtMDgtMDFUMDc6MDA6MDBaMD0CAQYCAQEENbR21I+a
+8+byMXo3NPRoDWQmSXQF2EcCeBoD4GaL//ZCRETp9rGFPSg1KekCP7Kr9HAqw09m
+MEICAQcCAQEEOlVJozYYBdugybShbiiMsejDMNeCbZq6CrzGBwW6GBy+DGWxJI91
+Y3ouXN4TZUhuVvLvN1b0m5T3ggQwggFaAgERAgEBBIIBUDGCAUwwCwICBqwCAQEE
+AhYAMAsCAgatAgEBBAIMADALAgIGsAIBAQQCFgAwCwICBrICAQEEAgwAMAsCAgaz
+AgEBBAIMADALAgIGtAIBAQQCDAAwCwICBrUCAQEEAgwAMAsCAga2AgEBBAIMADAM
+AgIGpQIBAQQDAgEBMAwCAgarAgEBBAMCAQEwDAICBq4CAQEEAwIBADAMAgIGrwIB
+AQQDAgEAMAwCAgaxAgEBBAMCAQAwGwICBqcCAQEEEgwQMTAwMDAwMDIyNTMyNTkw
+MTAbAgIGqQIBAQQSDBAxMDAwMDAwMjI1MzI1OTAxMB8CAgaoAgEBBBYWFDIwMTYt
+MDctMjNUMDY6MjE6MTFaMB8CAgaqAgEBBBYWFDIwMTYtMDctMjNUMDY6MjE6MTFa
+MCACAgamAgEBBBcMFWNvbS56aGlodS50ZXN0LnRlc3RfMaCCDmUwggV8MIIEZKAD
+AgECAggO61eH554JjTANBgkqhkiG9w0BAQUFADCBljELMAkGA1UEBhMCVVMxEzAR
+BgNVBAoMCkFwcGxlIEluYy4xLDAqBgNVBAsMI0FwcGxlIFdvcmxkd2lkZSBEZXZl
+bG9wZXIgUmVsYXRpb25zMUQwQgYDVQQDDDtBcHBsZSBXb3JsZHdpZGUgRGV2ZWxv
+cGVyIFJlbGF0aW9ucyBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0xNTExMTMw
+MjE1MDlaFw0yMzAyMDcyMTQ4NDdaMIGJMTcwNQYDVQQDDC5NYWMgQXBwIFN0b3Jl
+IGFuZCBpVHVuZXMgU3RvcmUgUmVjZWlwdCBTaWduaW5nMSwwKgYDVQQLDCNBcHBs
+ZSBXb3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9uczETMBEGA1UECgwKQXBwbGUg
+SW5jLjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQClz4H9JaKBW9aH7SPaMxyO4iPApcQmyz3Gn+xKDVWG/6QC15fKOVRtfX+yVBid
+xCxScY5ke4LOibpJ1gjltIhxzz9bRi7GxB24A6lYogQ+IXjV27fQjhKNg0xbKmg3
+k8LyvR7E0qEMSlhSqxLj7d0fmBWQNS3CzBLKjUiB91h4VGvojDE2H0oGDEdU8zeQ
+uLKSiX1fpIVK4cCc4Lqku4KXY/Qrk8H9Pm/KwfU8qY9SGsAlCnYO3v6Z/v/Ca/Vb
+XqxzUUkIVonMQ5DMjoEC0KCXtlyxoWlph5AQaCYmObgdEHOwCl3Fc9DfdjvYLdmI
+HuPsB8/ijtDT+iZVge/iA0kjAgMBAAGjggHXMIIB0zA/BggrBgEFBQcBAQQzMDEw
+LwYIKwYBBQUHMAGGI2h0dHA6Ly9vY3NwLmFwcGxlLmNvbS9vY3NwMDMtd3dkcjA0
+MB0GA1UdDgQWBBSRpJz8xHa3n6CK9E31jzZd7SsEhTAMBgNVHRMBAf8EAjAAMB8G
+A1UdIwQYMBaAFIgnFwmpthhgi+zruvZHWcVSVKO3MIIBHgYDVR0gBIIBFTCCAREw
+ggENBgoqhkiG92NkBQYBMIH+MIHDBggrBgEFBQcCAjCBtgyBs1JlbGlhbmNlIG9u
+IHRoaXMgY2VydGlmaWNhdGUgYnkgYW55IHBhcnR5IGFzc3VtZXMgYWNjZXB0YW5j
+ZSBvZiB0aGUgdGhlbiBhcHBsaWNhYmxlIHN0YW5kYXJkIHRlcm1zIGFuZCBjb25k
+aXRpb25zIG9mIHVzZSwgY2VydGlmaWNhdGUgcG9saWN5IGFuZCBjZXJ0aWZpY2F0
+aW9uIHByYWN0aWNlIHN0YXRlbWVudHMuMDYGCCsGAQUFBwIBFipodHRwOi8vd3d3
+LmFwcGxlLmNvbS9jZXJ0aWZpY2F0ZWF1dGhvcml0eS8wDgYDVR0PAQH/BAQDAgeA
+MBAGCiqGSIb3Y2QGCwEEAgUAMA0GCSqGSIb3DQEBBQUAA4IBAQANphvTLj3jWysH
+bkKWbNPojEMwgl/gXNGNvr0PvRr8JZLbjIXDgFnf4+LXLgUUrA3btrj+/DUufMut
+F2uOfx/kd7mxZ5W0E16mGYZ2+FogledjjA9z/Ojtxh+umfhlSFyg4Cg6wBA3Lbmg
+BDkfc7nIBf3y3n8aKipuKwH8oCBc2et9J6Yz+PWY4L5E27FMZ/xuCk/J4gao0pfz
+p45rUaJahHVl0RYEYuPBX/UIqc9o2ZIAycGMs/iNAGS6WGDAfK+PdcppuVsq1h1o
+bphC9UynNxmbzDscehlD86Ntv0hgBgw2kivs3hi1EdotI9CO/KBpnBcbnoB7OUdF
+MGEvxxOoMIIEIjCCAwqgAwIBAgIIAd68xDltoBAwDQYJKoZIhvcNAQEFBQAwYjEL
+MAkGA1UEBhMCVVMxEzARBgNVBAoTCkFwcGxlIEluYy4xJjAkBgNVBAsTHUFwcGxl
+IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRYwFAYDVQQDEw1BcHBsZSBSb290IENB
+MB4XDTEzMDIwNzIxNDg0N1oXDTIzMDIwNzIxNDg0N1owgZYxCzAJBgNVBAYTAlVT
+MRMwEQYDVQQKDApBcHBsZSBJbmMuMSwwKgYDVQQLDCNBcHBsZSBXb3JsZHdpZGUg
+RGV2ZWxvcGVyIFJlbGF0aW9uczFEMEIGA1UEAww7QXBwbGUgV29ybGR3aWRlIERl
+dmVsb3BlciBSZWxhdGlvbnMgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKOFSmy1aqyCQ5SOmM7uxfuH8mkbw0
+U3rOfGOAYXdkXqUHI7Y5/lAtFVZYcC1+xG7BSoU+L/DehBqhV8mvexj/avoVEkkV
+CBmsqtsqMu2WY2hSFT2Miuy/axiV4AOsAX2XBWfODoWVN2rtCbauZ81RZJ/GXNG8
+V25nNYB2NqSHgW44j9grFU57Jdhav06DwY3Sk9UacbVgnJ0zTlX5ElgMhrgWDcHl
+d0WNUEi6Ky3klIXh6MSdxmilsKP8Z35wugJZS3dCkTm59c3hTO/AO0iMpuUhXf1q
+arunFjVg0uat80YpyejDi+l5wGphZxWy8P3laLxiX27Pmd3vG2P+kmWrAgMBAAGj
+gaYwgaMwHQYDVR0OBBYEFIgnFwmpthhgi+zruvZHWcVSVKO3MA8GA1UdEwEB/wQF
+MAMBAf8wHwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/CF4wLgYDVR0fBCcw
+JTAjoCGgH4YdaHR0cDovL2NybC5hcHBsZS5jb20vcm9vdC5jcmwwDgYDVR0PAQH/
+BAQDAgGGMBAGCiqGSIb3Y2QGAgEEAgUAMA0GCSqGSIb3DQEBBQUAA4IBAQBPz+9Z
+viz1smwvj+4ThzLoBTWobot9yWkMudkXvHcs1Gfi/ZptOllc34MBvbKuKmFysa/N
+w0Uwj6ODDc4dR7Txk4qjdJukw5hyhzs+r0ULklS5MruQGFNrCk4QttkdUGwhgAqJ
+TleMa1s8Pab93vcNIx0LSiaHP7qRkkykGRIZbVf1eliHe2iK5IaMSuviSRSqpd1V
+AKmuu0swruGgsbwpgOYJd+W+NKIByn/c4grmO7i77LpilfMFY0GCzQ87HUyVpNur
++cmV6U/kTecmmYHpvPm0KdIBembhLoz2IYrF+Hjhga6/05Cdqa3zr/04GpZnMBxR
+pVzscYqCtGwPDBUfMIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQsw
+CQYDVQQGEwJVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUg
+Q2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0Ew
+HhcNMDYwNDI1MjE0MDM2WhcNMzUwMjA5MjE0MDM2WjBiMQswCQYDVQQGEwJVUzET
+MBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlv
+biBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQDkkakJH5HbHkdQ6wXtXnmELes2oldMVeyLGYne
++Uts9QerIjAC6Bg++FAJ039BqJj50cpmnCRrEdCju+QbKsMflZ56DKRHi1vUFjcz
+y8QPTc4UadHJGXL1XQ7Vf1+b8iUDulWPTV0N8WQ1IxVLFVkds5T39pyez1C6wVhQ
+Z48ItCD3y6wsIG9wtj8BMIy3Q88PnT3zK0koGsj+zrW5DtleHNbLPbU6rfQPDgCS
+C7EhFi501TwN22IWq6NxkkdTVcGvL0Gz+PvjcM3mo0xFfh9Ma1CWQYnEdGILEINB
+hzOKgbEwWOxaBDKMaLOPHd5lc/9nXmW8Sdh2nzMUZaF3lMktAgMBAAGjggF6MIIB
+djAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUK9Bp
+R5R2Cf70a40uQKb3R01/CF4wHwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/
+CF4wggERBgNVHSAEggEIMIIBBDCCAQAGCSqGSIb3Y2QFATCB8jAqBggrBgEFBQcC
+ARYeaHR0cHM6Ly93d3cuYXBwbGUuY29tL2FwcGxlY2EvMIHDBggrBgEFBQcCAjCB
+thqBs1JlbGlhbmNlIG9uIHRoaXMgY2VydGlmaWNhdGUgYnkgYW55IHBhcnR5IGFz
+c3VtZXMgYWNjZXB0YW5jZSBvZiB0aGUgdGhlbiBhcHBsaWNhYmxlIHN0YW5kYXJk
+IHRlcm1zIGFuZCBjb25kaXRpb25zIG9mIHVzZSwgY2VydGlmaWNhdGUgcG9saWN5
+IGFuZCBjZXJ0aWZpY2F0aW9uIHByYWN0aWNlIHN0YXRlbWVudHMuMA0GCSqGSIb3
+DQEBBQUAA4IBAQBcNplMLXi37Yyb3PN3m/J20ncwT8EfhYOFG5k9RzfyqZtAjizU
+sZAS2L70c5vu0mQPy3lPNNiiPvl4/2vIB+x9OYOLUyDTOMSxv5pPCmv/K/xZpwUJ
+fBdAVhEedNO3iyM7R6PVbyTi69G3cN8PReEnyvFteO3ntRcXqNx+IjXKJdXZD9Zr
+1KIkIxH3oayPc4FgxhtbCS+SsvhESPBgOJ4V9T0mZyCKM2r3DYLP3uujL/lTaltk
+wGMzd/c6ByxW69oPIQ7aunMZT7XZNn/Bh1XZp5m5MkL72NVxnn6hUrcbvZNCJBIq
+xw8dtk2cXmPIS4AXUKqK1drk/NAJBzewdXUhMYIByzCCAccCAQEwgaMwgZYxCzAJ
+BgNVBAYTAlVTMRMwEQYDVQQKDApBcHBsZSBJbmMuMSwwKgYDVQQLDCNBcHBsZSBX
+b3JsZHdpZGUgRGV2ZWxvcGVyIFJlbGF0aW9uczFEMEIGA1UEAww7QXBwbGUgV29y
+bGR3aWRlIERldmVsb3BlciBSZWxhdGlvbnMgQ2VydGlmaWNhdGlvbiBBdXRob3Jp
+dHkCCA7rV4fnngmNMAkGBSsOAwIaBQAwDQYJKoZIhvcNAQEBBQAEggEAasPtnide
+NWyfUtewW9OSgcQA8pW+5tWMR0469cBPZR84uJa0gyfmPspySvbNOAwnrwzZHYLa
+ujOxZLip4DUw4F5s3QwUa3y4BXpF4J+NSn9XNvxNtnT/GcEQtCuFwgJ0o3F0ilhv
+MTHrwiwyx/vr+uNDqlORK8lfK+1qNp+A/kzh8eszMrn4JSeTh9ZYxLHE56WkTQGD
+VZXl0gKgxSOmDrcp1eQxdlymzrPv9U60wUJ0bkPfrU9qZj3mJrmrkQk61JTe3j6/
+QfjfFBG9JG2mUmYQP1KQ3SypGHzDW8vngvsGu//tNU0NFfOqQu4bYU4VpQl0nPtD
+4B85NkrgvQsWAQ==
+-----END PKCS7-----`
+
+func TestVerifyFirefoxAddon(t *testing.T) {
+	fixture := UnmarshalTestFixture(FirefoxAddonFixture)
+	p7, err := Parse(fixture.Input)
+	if err != nil {
+		t.Errorf("Parse encountered unexpected error: %v", err)
+	}
+	p7.Content = FirefoxAddonContent
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(FirefoxAddonRootCert)
+	if err := p7.VerifyWithChain(certPool); err != nil {
+		t.Errorf("Verify failed with error: %v", err)
+	}
+	// Verify the certificate chain to make sure the identified root
+	// is the one we expect
+	ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, p7.Signers[0].IssuerAndSerialNumber)
+	if ee == nil {
+		t.Errorf("No end-entity certificate found for signer")
+	}
+	signingTime, _ := time.Parse(time.RFC3339, "2017-02-23 09:06:16-05:00")
+	chains, err := verifyCertChain(ee, p7.Certificates, certPool, signingTime)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(chains) != 1 {
+		t.Errorf("Expected to find one chain, but found %d", len(chains))
+	}
+	if len(chains[0]) != 3 {
+		t.Errorf("Expected to find three certificates in chain, but found %d", len(chains[0]))
+	}
+	if chains[0][0].Subject.CommonName != "tabscope@xuldev.org" {
+		t.Errorf("Expected to find EE certificate with subject 'tabscope@xuldev.org', but found '%s'", chains[0][0].Subject.CommonName)
+	}
+	if chains[0][1].Subject.CommonName != "production-signing-ca.addons.mozilla.org" {
+		t.Errorf("Expected to find intermediate certificate with subject 'production-signing-ca.addons.mozilla.org', but found '%s'", chains[0][1].Subject.CommonName)
+	}
+	if chains[0][2].Subject.CommonName != "root-ca-production-amo" {
+		t.Errorf("Expected to find root certificate with subject 'root-ca-production-amo', but found '%s'", chains[0][2].Subject.CommonName)
+	}
+}
+
+var FirefoxAddonContent = []byte(`Signature-Version: 1.0
+MD5-Digest-Manifest: KjRavc6/KNpuT1QLcB/Gsg==
+SHA1-Digest-Manifest: 5Md5nUg+U7hQ/UfzV+xGKWOruVI=
+
+`)
+
+var FirefoxAddonFixture = `
+-----BEGIN PKCS7-----
+MIIQTAYJKoZIhvcNAQcCoIIQPTCCEDkCAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3
+DQEHAaCCDL0wggW6MIIDoqADAgECAgYBVpobWVwwDQYJKoZIhvcNAQELBQAwgcUx
+CzAJBgNVBAYTAlVTMRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYD
+VQQLEyZNb3ppbGxhIEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTExMC8G
+A1UEAxMocHJvZHVjdGlvbi1zaWduaW5nLWNhLmFkZG9ucy5tb3ppbGxhLm9yZzE0
+MDIGCSqGSIb3DQEJARYlc2VydmljZXMtb3BzK2FkZG9uc2lnbmluZ0Btb3ppbGxh
+LmNvbTAeFw0xNjA4MTcyMDA0NThaFw0yMTA4MTYyMDA0NThaMHYxEzARBgNVBAsT
+ClByb2R1Y3Rpb24xCzAJBgNVBAYTAlVTMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3
+MQ8wDQYDVQQKEwZBZGRvbnMxCzAJBgNVBAgTAkNBMRwwGgYDVQQDFBN0YWJzY29w
+ZUB4dWxkZXYub3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAv6e0
+mPD8dt4J8HTNNq4ODns2DV6Weh1hllCIFvOeu1u3UrR03st0BMY8OXYwr/NvRVjg
+bA8gRySWAL+XqLzbhtXNeNegAoxrF+3mYY5rJjsLj/FGI6P6OXjngqwgm9VTBl7m
+jh/KXBSwYoUcavJo6cmk8sCFwoblyQiv+tsWaUCOI6zMzubNtIS+GFvET9y/VZMP
+j6mk8O10wBgJF5MMtA19va3qXy7aCZ7DnZp1l3equd/L6t324TtXoqx6xWQKo6TM
+I0mcTlKvm6TKegTGBCyGn3JRARoIJv4AW1qqgyaHXf9EoY2pKT8Avkri5++NuSJ6
+jtO4k/diBA2MZU20U0KGffYZNTxKDqd6XtI6y1tJPd/OWRFyU+mHntkcm9sar7L3
+nPKujHRox2re10ec1WBnJE3PjlAoesNjxzp+xs2mGGc8DX9NuWn+1uK9xmgGIIMl
+OFfyQ4s0G6hKp5goFcrFZxmexu0ZahOs8vZf8xDBW7yR1zToQElOXHvrscM386os
+kOF9IxQZfcCoPuNQVg1haCONNkx0oau3RQQlOSAZtC79b+rBjQ5JYfjRLYAworf2
+xQaprCh33TD1dTBrvzEbCGszgkN53Vqh5TFBjbU/NyldOkGvK8Xf6WhT5u+aftnV
+lbuE2McAg6x1AlloUZq6PNTBpz7zypcIISnQ+y8CAwEAATANBgkqhkiG9w0BAQsF
+AAOCAgEAIBoo2+OEYNCgP/IbUj9azaf/lde1q4AK/uTMoUeS5WcrXd8aqA0Y1qV7
+xUALgDQAExXgqcOMGu4mPMaoZDgwGI4Tj7XPJQq5Z5zYxpRf/Wtzae33T9BF6QPW
+v5xiRYuol+FbEtqRHZqxDWtIrd1MWBy3wjO3pLPdzDM9jWh+HLxdGWThJszaZp3T
+CqsOx+l9W0Q7qM5ioZpHStgXDfhw38Lg++kLnzcX9MqsjYyezdwE4krqW6hK3+4S
+0LZE4dTgsy8JULkyAF3HrPWEXESnD7c4mx6owZe+BNDK5hsVM/obAqH7sJq/igbM
+5N1l832p/ws8l5xKOr3qBWSzWn6u7ExvqG6Ckh0foJOVXvzGqvrXcoiBGV8S9Z7c
+DghUvMt6b0pZ0ildRCHfTUz7eG3g4MhfbjupR7b+L9FWEJhcd/H0dxpw7SKYha/n
+ePuRL7MXmbW8WLMqO/ImxzL8TPOB3pUg3nITfubV6gpPBmn+0nwbqYUmggJuwgvK
+I2GpN2Ny6EErZy17EEgyhJygJZMj+UzQjC781xxsl3ljpYEqqwgRLIZBSBUD5dXj
+XBuU24w162SeSyHZzkBbuv6lr52pqoZyFrG29DCHECgO9ZmNWgSpiWSkh+vExAG7
+wNs0y61t2HUG+BCMGPQ9sOzouyTfrnLVAWwzswGftFYQfoIBeJIwggb7MIIE46AD
+AgECAgMQAAIwDQYJKoZIhvcNAQEMBQAwfTELMAkGA1UEBhMCVVMxHDAaBgNVBAoT
+E01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEgQU1PIFByb2R1
+Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNhLXByb2R1Y3Rp
+b24tYW1vMB4XDTE1MDMxNzIzNTI0MloXDTI1MDMxNDIzNTI0MlowgcUxCzAJBgNV
+BAYTAlVTMRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYDVQQLEyZN
+b3ppbGxhIEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTExMC8GA1UEAxMo
+cHJvZHVjdGlvbi1zaWduaW5nLWNhLmFkZG9ucy5tb3ppbGxhLm9yZzE0MDIGCSqG
+SIb3DQEJARYlc2VydmljZXMtb3BzK2FkZG9uc2lnbmluZ0Btb3ppbGxhLmNvbTCC
+AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMLMM9m2HBLhCiO9mhljpehT
+hxpzlCnxluzDZ51I/H7MvBbIvZBm9zSpHdffubSsak2qYE69d+ebTa/CK83WIosM
+24/2Qp7n/GGaPJcCC4Y3JkrCsgA8+wV2MbFlKSv+qMdvI/sE3BPYDMCjVPMhHmIP
+XaPWd42OoHpI8R3GGUtVnR3Hm76pa2+v6TwgeMiO8om+ogGufiyv6FNMZ5NuY1Z9
+aLNEvehnAzSfddQyki+6FJd7XkgZbP7pb1Kl8yYgiy4piBerJ9H09uPehffE3Ell
+3cApQL3+0kjaUX4scMjuNQDMKziRZkYgJAM+qA9WA5Jn77AjerQBWQeEev1PWHYh
+0IDlgS/a0bjKmVjNZYG6adrY/R5/whzWGFCIE1UfhPm6PdN0557qvF838C2RFHsI
+KzV6KQf0chMjpa02tPaIctjVhnDQZZNKm2ZfLOt9kQ57Is/e6KxH7pYMit46+s99
+lYM7ZquvWbK19b1Ili/6S1BxSzd3wztgfN5jGsc+jCCYLm+AcVtfNKc8cFZHXKrB
+CwhGmdbWDSBCicZNA7FKJpO3oIx26VPF2XUldA/T5Mh/POGLilK3t9m9qbjEyDp1
+EwoBToOR/aMrdnNYvSWp0g/GHMzSfJjjXyAqrZY2itam/IJd8r9FoRAzevPt/zTX
+BET3INoiCDGRH0XrxUYtAgMGVTejggE5MIIBNTAMBgNVHRMEBTADAQH/MA4GA1Ud
+DwEB/wQEAwIBBjAWBgNVHSUBAf8EDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUdHxf
+FKXipZLjs20GqIUdNkQXH4gwgagGA1UdIwSBoDCBnYAUs7zqWHSr4W54KrKrnCMe
+qGMsl7ehgYGkfzB9MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jw
+b3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5n
+IFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW+CAQEwMwYJ
+YIZIAYb4QgEEBCYWJGh0dHA6Ly9hZGRvbnMubW96aWxsYS5vcmcvY2EvY3JsLnBl
+bTANBgkqhkiG9w0BAQwFAAOCAgEArde/fdjb7TE0eH7Ij7xU4JbcSyhY3cQhVYCw
+Fg+Q/2pj+NAfazcjUuLWA0Y/YZs9HOx6j+ZAqO4C/xfMP4RDs9IypxvzHDU6SXgD
+RK6uOKtS07HXLcXgFUBvJEQhbT/h5+IQOA4/GcpCshfD6iyiBBi+IocR+tnKPCuZ
+T3m1t60Eja/MkPKG/Gx8vSodHvlTTsJ2GzjUEANveCZOnlAdp9fjTvFZny9qqnbg
+sfVbuTqKndbCFW5QLXfkna6jBqMrY0+CpMYY2oJ5gwpHbE/7hhukjxGCTcpv7r/O
+M53bb/DZnybDlLLepacljvz7DBA1O1FFtEhf9MR+vyvmBpniAyKQhqG2hsVGurE1
+nBcE+oteZWar2lMp6+etDAb9DRC+jZv0aEQs2o/qQwyD8AGquLgBsJq5Jz3gGxzn
+4r3vGu2lV8VdzIm0C8sOFSWTmTZxQmJbF8xSsQBojnsvEah4DPER+eAt6qKolaWe
+s4drJQjzFyC7HJn2VqalpCwbe9CdMB7eRqzeP6GujJBi80/gx0pAysUtuKKpH5IJ
+WbXAOszfrjb3CaHafYZDnwPoOfj74ogFzjt2f54jwnU+ET/byfjZ7J8SLH316C1V
+HrvFXcTzyMV4aRluVPjPg9x1G58hMIbeuT4GpwQUNdJ9uL8t65v0XwG2t6Y7jpRO
+sFVxBtgxggNXMIIDUwIBATCB0DCBxTELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE01v
+emlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEgQU1PIFByb2R1Y3Rp
+b24gU2lnbmluZyBTZXJ2aWNlMTEwLwYDVQQDEyhwcm9kdWN0aW9uLXNpZ25pbmct
+Y2EuYWRkb25zLm1vemlsbGEub3JnMTQwMgYJKoZIhvcNAQkBFiVzZXJ2aWNlcy1v
+cHMrYWRkb25zaWduaW5nQG1vemlsbGEuY29tAgYBVpobWVwwCQYFKw4DAhoFAKBd
+MBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTE2MDgx
+NzIwMDQ1OFowIwYJKoZIhvcNAQkEMRYEFAxlGvNFSx+Jqj70haE8b7UZk+2GMA0G
+CSqGSIb3DQEBAQUABIICADsDlrucYRgwq9o2QSsO6X6cRa5Zu6w+1n07PTIyc1zn
+Pi1cgkkWZ0kZBHDrJ5CY33yRQPl6I1tHXaq7SkOSdOppKhpUmBiKZxQRAZR21QHk
+R3v1XS+st/o0N+0btv3YoplUifLIwtH89oolxqlStChELu7FuOBretdhx/z12ytA
+EhIIS53o/XjDL7XKJbQA02vzOtOC/Eq6p8BI7F3y6pvtmJIRkeGv+u6ssJa6g5q8
+74w8hHXaH94Z9+hDPqjNWlsXJHgPdAKiEjzDz9oLkvDyX4Pd8JMK5ILskirpG+hj
+Q8jkTc5oYwyuSlBAUTGxW6ZbuOrtfVZvOVtRL/ixuiFiVlJ+JOQOxrtK19ukamsI
+iacFlbLgiA7w0HCtm2DsT9aL67/1e4rJ0lv0MjnQYUMmKQy7g0Gd3+nQPU9pn+Lf
+Z/UmSNWiJ8Csc/seDMyzT6jrzcGPfoSVaUowH0wGrI9If1snwcr+mMg7dWRGf1fm
+y/dcVSzed0ax4LqDmike1EshU+51cKWWlnhyNHK4KH+0fNsBQ0c6clrFpGx9MPmV
+YXie6C+LWkh5x12RU0sJt/SmSZV6q9VliIkX+yY3jBrC/pKgRahtcIyq46Da1E6K
+lc15Euur3NfGow+nott0Z8XutpYdK/2vBKcIh9JOdkd+oe6pcIP6hnhHRp53wqmG
+-----END PKCS7-----`
+
+var FirefoxAddonRootCert = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIGYTCCBEmgAwIBAgIBATANBgkqhkiG9w0BAQwFADB9MQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBB
+TU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2Et
+cHJvZHVjdGlvbi1hbW8wHhcNMTUwMzE3MjI1MzU3WhcNMjUwMzE0MjI1MzU3WjB9
+MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0G
+A1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAd
+BgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW8wggIgMA0GCSqGSIb3DQEBAQUA
+A4ICDQAwggIIAoICAQC0u2HXXbrwy36+MPeKf5jgoASMfMNz7mJWBecJgvlTf4hH
+JbLzMPsIUauzI9GEpLfHdZ6wzSyFOb4AM+D1mxAWhuZJ3MDAJOf3B1Rs6QorHrl8
+qqlNtPGqepnpNJcLo7JsSqqE3NUm72MgqIHRgTRsqUs+7LIPGe7262U+N/T0LPYV
+Le4rZ2RDHoaZhYY7a9+49mHOI/g2YFB+9yZjE+XdplT2kBgA4P8db7i7I0tIi4b0
+B0N6y9MhL+CRZJyxdFe2wBykJX14LsheKsM1azHjZO56SKNrW8VAJTLkpRxCmsiT
+r08fnPyDKmaeZ0BtsugicdipcZpXriIGmsZbI12q5yuwjSELdkDV6Uajo2n+2ws5
+uXrP342X71WiWhC/dF5dz1LKtjBdmUkxaQMOP/uhtXEKBrZo1ounDRQx1j7+SkQ4
+BEwjB3SEtr7XDWGOcOIkoJZWPACfBLC3PJCBWjTAyBlud0C5n3Cy9regAAnOIqI1
+t16GU2laRh7elJ7gPRNgQgwLXeZcFxw6wvyiEcmCjOEQ6PM8UQjthOsKlszMhlKw
+vjyOGDoztkqSBy/v+Asx7OW2Q7rlVfKarL0mREZdSMfoy3zTgtMVCM0vhNl6zcvf
+5HNNopoEdg5yuXo2chZ1p1J+q86b0G5yJRMeT2+iOVY2EQ37tHrqUURncCy4uwIB
+A6OB7TCB6jAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAWBgNVHSUBAf8E
+DDAKBggrBgEFBQcDAzCBkgYDVR0jBIGKMIGHoYGBpH8wfTELMAkGA1UEBhMCVVMx
+HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
+QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNh
+LXByb2R1Y3Rpb24tYW1vggEBMB0GA1UdDgQWBBSzvOpYdKvhbngqsqucIx6oYyyX
+tzANBgkqhkiG9w0BAQwFAAOCAgEAaNSRYAaECAePQFyfk12kl8UPLh8hBNidP2H6
+KT6O0vCVBjxmMrwr8Aqz6NL+TgdPmGRPDDLPDpDJTdWzdj7khAjxqWYhutACTew5
+eWEaAzyErbKQl+duKvtThhV2p6F6YHJ2vutu4KIciOMKB8dslIqIQr90IX2Usljq
+8Ttdyf+GhUmazqLtoB0GOuESEqT4unX6X7vSGu1oLV20t7t5eCnMMYD67ZBn0YIU
+/cm/+pan66hHrja+NeDGF8wabJxdqKItCS3p3GN1zUGuJKrLykxqbOp/21byAGog
+Z1amhz6NHUcfE6jki7sM7LHjPostU5ZWs3PEfVVgha9fZUhOrIDsyXEpCWVa3481
+LlAq3GiUMKZ5DVRh9/Nvm4NwrTfB3QkQQJCwfXvO9pwnPKtISYkZUqhEqvXk5nBg
+QCkDSLDjXTx39naBBGIVIqBtKKuVTla9enngdq692xX/CgO6QJVrwpqdGjebj5P8
+5fNZPABzTezG3Uls5Vp+4iIWVAEDkK23cUj3c/HhE+Oo7kxfUeu5Y1ZV3qr61+6t
+ZARKjbu1TuYQHf0fs+GwID8zeLc2zJL7UzcHFwwQ6Nda9OJN4uPAuC/BKaIpxCLL
+26b24/tRam4SJjqpiq20lynhUrmTtt6hbG3E1Hpy3bmkt2DYnuMFwEx2gfXNcnbT
+wNuvFqc=
+-----END CERTIFICATE-----`)
+
+// sign a document with openssl and verify the signature with pkcs7.
+// this uses a chain of root, intermediate and signer cert, where the
+// intermediate is added to the certs but the root isn't.
+func TestSignWithOpenSSLAndVerify(t *testing.T) {
+	content := []byte(`
+A ship in port is safe,
+but that's not what ships are built for.
+-- Grace Hopper`)
+	// write the content to a temp file
+	tmpContentFile, err := ioutil.TempFile("", "TestSignWithOpenSSLAndVerify_content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
+	sigalgs := []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
+		x509.SHA256WithRSA,
+		x509.SHA512WithRSA,
+		x509.ECDSAWithSHA1,
+		x509.ECDSAWithSHA256,
+		x509.ECDSAWithSHA384,
+		x509.ECDSAWithSHA512,
+	}
+	for _, sigalgroot := range sigalgs {
+		rootCert, err := createTestCertificateByIssuer("PKCS7 Test Root CA", nil, sigalgroot, true)
+		if err != nil {
+			t.Fatalf("test %s: cannot generate root cert: %s", sigalgroot, err)
+		}
+		truststore := x509.NewCertPool()
+		truststore.AddCert(rootCert.Certificate)
+		for _, sigalginter := range sigalgs {
+			interCert, err := createTestCertificateByIssuer("PKCS7 Test Intermediate Cert", rootCert, sigalginter, true)
+			if err != nil {
+				t.Fatalf("test %s/%s: cannot generate intermediate cert: %s", sigalgroot, sigalginter, err)
+			}
+			// write the intermediate cert to a temp file
+			tmpInterCertFile, err := ioutil.TempFile("", "TestSignWithOpenSSLAndVerify_intermediate")
+			if err != nil {
+				t.Fatal(err)
+			}
+			fd, err := os.OpenFile(tmpInterCertFile.Name(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: interCert.Certificate.Raw})
+			fd.Close()
+			for _, sigalgsigner := range sigalgs {
+				signerCert, err := createTestCertificateByIssuer("PKCS7 Test Signer Cert", interCert, sigalgsigner, false)
+				if err != nil {
+					t.Fatalf("test %s/%s/%s: cannot generate signer cert: %s", sigalgroot, sigalginter, sigalgsigner, err)
+				}
+
+				// write the signer cert to a temp file
+				tmpSignerCertFile, err := ioutil.TempFile("", "TestSignWithOpenSSLAndVerify_signer")
+				if err != nil {
+					t.Fatal(err)
+				}
+				fd, err = os.OpenFile(tmpSignerCertFile.Name(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+				if err != nil {
+					t.Fatal(err)
+				}
+				pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: signerCert.Certificate.Raw})
+				fd.Close()
+
+				// write the signer key to a temp file
+				tmpSignerKeyFile, err := ioutil.TempFile("", "TestSignWithOpenSSLAndVerify_key")
+				if err != nil {
+					t.Fatal(err)
+				}
+				fd, err = os.OpenFile(tmpSignerKeyFile.Name(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var derKey []byte
+				priv := *signerCert.PrivateKey
+				switch priv.(type) {
+				case *rsa.PrivateKey:
+					derKey = x509.MarshalPKCS1PrivateKey(priv.(*rsa.PrivateKey))
+					pem.Encode(fd, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: derKey})
+				case *ecdsa.PrivateKey:
+					derKey, err = x509.MarshalECPrivateKey(priv.(*ecdsa.PrivateKey))
+					if err != nil {
+						t.Fatal(err)
+					}
+					pem.Encode(fd, &pem.Block{Type: "EC PRIVATE KEY", Bytes: derKey})
+				}
+				fd.Close()
+
+				// write the root cert to a temp file
+				tmpSignedFile, err := ioutil.TempFile("", "TestSignWithOpenSSLAndVerify_signature")
+				if err != nil {
+					t.Fatal(err)
+				}
+				// call openssl to sign the content
+				opensslCMD := exec.Command("openssl", "smime", "-sign", "-nodetach",
+					"-in", tmpContentFile.Name(), "-out", tmpSignedFile.Name(),
+					"-signer", tmpSignerCertFile.Name(), "-inkey", tmpSignerKeyFile.Name(),
+					"-certfile", tmpInterCertFile.Name(), "-outform", "PEM")
+				out, err := opensslCMD.CombinedOutput()
+				if err != nil {
+					t.Fatalf("test %s/%s/%s: openssl command failed with %s: %s", sigalgroot, sigalginter, sigalgsigner, err, out)
+				}
+
+				// verify the signed content
+				pemSignature, err := ioutil.ReadFile(tmpSignedFile.Name())
+				if err != nil {
+					t.Fatal(err)
+				}
+				fmt.Printf("%s\n", pemSignature)
+				derBlock, _ := pem.Decode(pemSignature)
+				if derBlock == nil {
+					break
+				}
+				p7, err := Parse(derBlock.Bytes)
+				if err != nil {
+					t.Fatalf("Parse encountered unexpected error: %v", err)
+				}
+				if err := p7.VerifyWithChain(truststore); err != nil {
+					t.Fatalf("Verify failed with error: %v", err)
+				}
+				// Verify the certificate chain to make sure the identified root
+				// is the one we expect
+				ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, p7.Signers[0].IssuerAndSerialNumber)
+				if ee == nil {
+					t.Fatalf("No end-entity certificate found for signer")
+				}
+				chains, err := verifyCertChain(ee, p7.Certificates, truststore, time.Now())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(chains) != 1 {
+					t.Fatalf("Expected to find one chain, but found %d", len(chains))
+				}
+				if len(chains[0]) != 3 {
+					t.Fatalf("Expected to find three certificates in chain, but found %d", len(chains[0]))
+				}
+				if chains[0][0].Subject.CommonName != "PKCS7 Test Signer Cert" {
+					t.Fatalf("Expected to find EE certificate with subject 'PKCS7 Test Signer Cert', but found '%s'", chains[0][0].Subject.CommonName)
+				}
+				if chains[0][1].Subject.CommonName != "PKCS7 Test Intermediate Cert" {
+					t.Fatalf("Expected to find intermediate certificate with subject 'PKCS7 Test Intermediate Cert', but found '%s'", chains[0][1].Subject.CommonName)
+				}
+				if chains[0][2].Subject.CommonName != "PKCS7 Test Root CA" {
+					t.Fatalf("Expected to find root certificate with subject 'PKCS7 Test Root CA', but found '%s'", chains[0][2].Subject.CommonName)
+				}
+				os.Remove(tmpSignerCertFile.Name()) // clean up
+				os.Remove(tmpSignerKeyFile.Name())  // clean up
+			}
+			os.Remove(tmpInterCertFile.Name()) // clean up
+		}
+	}
+	os.Remove(tmpContentFile.Name()) // clean up
+}


### PR DESCRIPTION
This patch adds the ability to both sign and verify
signatures that contain a certificate chain. The root
of the chain is expected to be provided separately via
an x509.CertPool passed to the Verifier.

The added FirefoxAddon test case uses a certificate
chain to check the addon signature against the Firefox
Root CA.