### PR TITLE
Make the signing digest algorithm configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: vet lint unused gosimple staticcheck test
+all: vet unused gosimple staticcheck test
 
 test:
 	go test -covermode=count -coverprofile=coverage.out .

--- a/decrypt.go
+++ b/decrypt.go
@@ -54,12 +54,12 @@ func (p7 *PKCS7) DecryptUsingPSK(key []byte) ([]byte, error) {
 
 func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
 	alg := eci.ContentEncryptionAlgorithm.Algorithm
-	if !alg.Equal(oidEncryptionAlgorithmDESCBC) &&
-		!alg.Equal(oidEncryptionAlgorithmDESEDE3CBC) &&
-		!alg.Equal(oidEncryptionAlgorithmAES256CBC) &&
-		!alg.Equal(oidEncryptionAlgorithmAES128CBC) &&
-		!alg.Equal(oidEncryptionAlgorithmAES128GCM) &&
-		!alg.Equal(oidEncryptionAlgorithmAES256GCM) {
+	if !alg.Equal(OIDEncryptionAlgorithmDESCBC) &&
+		!alg.Equal(OIDEncryptionAlgorithmDESEDE3CBC) &&
+		!alg.Equal(OIDEncryptionAlgorithmAES256CBC) &&
+		!alg.Equal(OIDEncryptionAlgorithmAES128CBC) &&
+		!alg.Equal(OIDEncryptionAlgorithmAES128GCM) &&
+		!alg.Equal(OIDEncryptionAlgorithmAES256GCM) {
 		fmt.Printf("Unsupported Content Encryption Algorithm: %s\n", alg)
 		return nil, ErrUnsupportedAlgorithm
 	}
@@ -89,13 +89,13 @@ func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
 	var err error
 
 	switch {
-	case alg.Equal(oidEncryptionAlgorithmDESCBC):
+	case alg.Equal(OIDEncryptionAlgorithmDESCBC):
 		block, err = des.NewCipher(key)
-	case alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
+	case alg.Equal(OIDEncryptionAlgorithmDESEDE3CBC):
 		block, err = des.NewTripleDESCipher(key)
-	case alg.Equal(oidEncryptionAlgorithmAES256CBC), alg.Equal(oidEncryptionAlgorithmAES256GCM):
+	case alg.Equal(OIDEncryptionAlgorithmAES256CBC), alg.Equal(OIDEncryptionAlgorithmAES256GCM):
 		fallthrough
-	case alg.Equal(oidEncryptionAlgorithmAES128GCM), alg.Equal(oidEncryptionAlgorithmAES128CBC):
+	case alg.Equal(OIDEncryptionAlgorithmAES128GCM), alg.Equal(OIDEncryptionAlgorithmAES128CBC):
 		block, err = aes.NewCipher(key)
 	}
 
@@ -103,7 +103,7 @@ func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	if alg.Equal(oidEncryptionAlgorithmAES128GCM) || alg.Equal(oidEncryptionAlgorithmAES256GCM) {
+	if alg.Equal(OIDEncryptionAlgorithmAES128GCM) || alg.Equal(OIDEncryptionAlgorithmAES256GCM) {
 		params := aesGCMParameters{}
 		paramBytes := eci.ContentEncryptionAlgorithm.Parameters.Bytes
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -74,10 +74,10 @@ func encryptAESGCM(content []byte, key []byte) ([]byte, *encryptedContentInfo, e
 	var algID asn1.ObjectIdentifier
 	if ContentEncryptionAlgorithm == EncryptionAlgorithmAES128GCM {
 		keyLen = 16
-		algID = oidEncryptionAlgorithmAES128GCM
+		algID = OIDEncryptionAlgorithmAES128GCM
 	} else {
 		keyLen = 32
-		algID = oidEncryptionAlgorithmAES256GCM
+		algID = OIDEncryptionAlgorithmAES256GCM
 	}
 	if key == nil {
 		// Create AES key
@@ -122,7 +122,7 @@ func encryptAESGCM(content []byte, key []byte) ([]byte, *encryptedContentInfo, e
 	}
 
 	eci := encryptedContentInfo{
-		ContentType: oidData,
+		ContentType: OIDData,
 		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
 			Algorithm: algID,
 			Parameters: asn1.RawValue{
@@ -169,9 +169,9 @@ func encryptDESCBC(content []byte, key []byte) ([]byte, *encryptedContentInfo, e
 
 	// Prepare ASN.1 Encrypted Content Info
 	eci := encryptedContentInfo{
-		ContentType: oidData,
+		ContentType: OIDData,
 		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
-			Algorithm:  oidEncryptionAlgorithmDESCBC,
+			Algorithm:  OIDEncryptionAlgorithmDESCBC,
 			Parameters: asn1.RawValue{Tag: 4, Bytes: iv},
 		},
 		EncryptedContent: marshalEncryptedContent(cyphertext),
@@ -229,7 +229,7 @@ func Encrypt(content []byte, recipients []*x509.Certificate) ([]byte, error) {
 			Version:               0,
 			IssuerAndSerialNumber: ias,
 			KeyEncryptionAlgorithm: pkix.AlgorithmIdentifier{
-				Algorithm: oidEncryptionAlgorithmRSA,
+				Algorithm: OIDEncryptionAlgorithmRSA,
 			},
 			EncryptedKey: encrypted,
 		}
@@ -249,7 +249,7 @@ func Encrypt(content []byte, recipients []*x509.Certificate) ([]byte, error) {
 
 	// Prepare outer payload structure
 	wrapper := contentInfo{
-		ContentType: oidEnvelopedData,
+		ContentType: OIDEnvelopedData,
 		Content:     asn1.RawValue{Class: 2, Tag: 0, IsCompound: true, Bytes: innerContent},
 	}
 
@@ -296,7 +296,7 @@ func EncryptUsingPSK(content []byte, key []byte) ([]byte, error) {
 
 	// Prepare outer payload structure
 	wrapper := contentInfo{
-		ContentType: oidEncryptedData,
+		ContentType: OIDEncryptedData,
 		Content:     asn1.RawValue{Class: 2, Tag: 0, IsCompound: true, Bytes: innerContent},
 	}
 

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -39,55 +39,55 @@ type unsignedData []byte
 
 var (
 	// Signed Data OIDs
-	oidData                   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 1}
-	oidSignedData             = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}
-	oidEnvelopedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 3}
-	oidEncryptedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 6}
-	oidAttributeContentType   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
-	oidAttributeMessageDigest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
-	oidAttributeSigningTime   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
+	OIDData                   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 1}
+	OIDSignedData             = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}
+	OIDEnvelopedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 3}
+	OIDEncryptedData          = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 6}
+	OIDAttributeContentType   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
+	OIDAttributeMessageDigest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
+	OIDAttributeSigningTime   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 5}
 
 	// Digest Algorithms
-	oidDigestAlgorithmSHA1   = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
-	oidDigestAlgorithmSHA256 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
-	oidDigestAlgorithmSHA384 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
-	oidDigestAlgorithmSHA512 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
+	OIDDigestAlgorithmSHA1   = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	OIDDigestAlgorithmSHA256 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
+	OIDDigestAlgorithmSHA384 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
+	OIDDigestAlgorithmSHA512 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
 
 	// Signature Algorithms
-	oidEncryptionAlgorithmRSA       = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
-	oidEncryptionAlgorithmRSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
-	oidEncryptionAlgorithmRSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
-	oidEncryptionAlgorithmRSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
-	oidEncryptionAlgorithmRSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}
+	OIDEncryptionAlgorithmRSA       = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	OIDEncryptionAlgorithmRSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
+	OIDEncryptionAlgorithmRSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
+	OIDEncryptionAlgorithmRSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
+	OIDEncryptionAlgorithmRSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}
 
-	oidEncryptionAlgorithmDSA     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
-	oidDigestAlgorithmECDSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 1}
-	oidDigestAlgorithmECDSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
-	oidDigestAlgorithmECDSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
-	oidDigestAlgorithmECDSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
+	OIDEncryptionAlgorithmDSA     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
+	OIDDigestAlgorithmECDSASHA1   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 1}
+	OIDDigestAlgorithmECDSASHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	OIDDigestAlgorithmECDSASHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
+	OIDDigestAlgorithmECDSASHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
 
-	oidEncryptionAlgorithmECDSAP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
-	oidEncryptionAlgorithmECDSAP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
-	oidEncryptionAlgorithmECDSAP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+	OIDEncryptionAlgorithmECDSAP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+	OIDEncryptionAlgorithmECDSAP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+	OIDEncryptionAlgorithmECDSAP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
 
 	// Encryption Algorithms
-	oidEncryptionAlgorithmDESCBC     = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 7}
-	oidEncryptionAlgorithmDESEDE3CBC = asn1.ObjectIdentifier{1, 2, 840, 113549, 3, 7}
-	oidEncryptionAlgorithmAES256CBC  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 42}
-	oidEncryptionAlgorithmAES128GCM  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 6}
-	oidEncryptionAlgorithmAES128CBC  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 2}
-	oidEncryptionAlgorithmAES256GCM  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 46}
+	OIDEncryptionAlgorithmDESCBC     = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 7}
+	OIDEncryptionAlgorithmDESEDE3CBC = asn1.ObjectIdentifier{1, 2, 840, 113549, 3, 7}
+	OIDEncryptionAlgorithmAES256CBC  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 42}
+	OIDEncryptionAlgorithmAES128GCM  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 6}
+	OIDEncryptionAlgorithmAES128CBC  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 2}
+	OIDEncryptionAlgorithmAES256GCM  = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 46}
 )
 
 func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
 	switch {
-	case oid.Equal(oidDigestAlgorithmSHA1), oid.Equal(oidDigestAlgorithmECDSASHA1):
+	case oid.Equal(OIDDigestAlgorithmSHA1), oid.Equal(OIDDigestAlgorithmECDSASHA1):
 		return crypto.SHA1, nil
-	case oid.Equal(oidDigestAlgorithmSHA256), oid.Equal(oidDigestAlgorithmECDSASHA256):
+	case oid.Equal(OIDDigestAlgorithmSHA256), oid.Equal(OIDDigestAlgorithmECDSASHA256):
 		return crypto.SHA256, nil
-	case oid.Equal(oidDigestAlgorithmSHA384), oid.Equal(oidDigestAlgorithmECDSASHA384):
+	case oid.Equal(OIDDigestAlgorithmSHA384), oid.Equal(OIDDigestAlgorithmECDSASHA384):
 		return crypto.SHA384, nil
-	case oid.Equal(oidDigestAlgorithmSHA512), oid.Equal(oidDigestAlgorithmECDSASHA512):
+	case oid.Equal(OIDDigestAlgorithmSHA512), oid.Equal(OIDDigestAlgorithmECDSASHA512):
 		return crypto.SHA512, nil
 	}
 	return crypto.Hash(0), ErrUnsupportedAlgorithm
@@ -95,26 +95,23 @@ func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
 
 // getDigestOIDForSignatureAlgorithm takes an x509.SignatureAlgorithm
 // and returns the corresponding OID digest algorithm
-//
-// FIXME: disabled because of bug 1357815 in sign.go
-//
-//func getDigestOIDForSignatureAlgorithm(digestAlg x509.SignatureAlgorithm) (asn1.ObjectIdentifier, error) {
-//	switch digestAlg {
-//	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
-//		return oidDigestAlgorithmSHA1, nil
-//	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
-//		return oidDigestAlgorithmSHA256, nil
-//	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
-//		return oidDigestAlgorithmSHA384, nil
-//	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
-//		return oidDigestAlgorithmSHA512, nil
-//	}
-//	return nil, fmt.Errorf("pkcs7: cannot convert hash to oid, unknown hash algorithm")
-//}
+func getDigestOIDForSignatureAlgorithm(digestAlg x509.SignatureAlgorithm) (asn1.ObjectIdentifier, error) {
+	switch digestAlg {
+	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
+		return OIDDigestAlgorithmSHA1, nil
+	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
+		return OIDDigestAlgorithmSHA256, nil
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
+		return OIDDigestAlgorithmSHA384, nil
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
+		return OIDDigestAlgorithmSHA512, nil
+	}
+	return nil, fmt.Errorf("pkcs7: cannot convert hash to oid, unknown hash algorithm")
+}
 
 // getOIDForEncryptionAlgorithm takes the private key type of the signer and
 // the OID of a digest algorithm to return the appropriate signerInfo.DigestEncryptionAlgorithm
-func getOIDForEncryptionAlgorithm(pkey interface{}, oidDigestAlg asn1.ObjectIdentifier) (asn1.ObjectIdentifier, error) {
+func getOIDForEncryptionAlgorithm(pkey interface{}, OIDDigestAlg asn1.ObjectIdentifier) (asn1.ObjectIdentifier, error) {
 	key, ok := pkey.(crypto.Signer)
 	if !ok {
 		return nil, errors.New("pkcs7: private key does not implement crypto.Signer")
@@ -126,26 +123,26 @@ func getOIDForEncryptionAlgorithm(pkey interface{}, oidDigestAlg asn1.ObjectIden
 	case *rsa.PublicKey:
 		switch {
 		default:
-			return oidEncryptionAlgorithmRSA, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA1):
-			return oidEncryptionAlgorithmRSASHA1, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA256):
-			return oidEncryptionAlgorithmRSASHA256, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA384):
-			return oidEncryptionAlgorithmRSASHA384, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA512):
-			return oidEncryptionAlgorithmRSASHA512, nil
+			return OIDEncryptionAlgorithmRSA, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA1):
+			return OIDEncryptionAlgorithmRSASHA1, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA256):
+			return OIDEncryptionAlgorithmRSASHA256, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA384):
+			return OIDEncryptionAlgorithmRSASHA384, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA512):
+			return OIDEncryptionAlgorithmRSASHA512, nil
 		}
 	case *ecdsa.PublicKey:
 		switch {
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA1):
-			return oidDigestAlgorithmECDSASHA1, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA256):
-			return oidDigestAlgorithmECDSASHA256, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA384):
-			return oidDigestAlgorithmECDSASHA384, nil
-		case oidDigestAlg.Equal(oidDigestAlgorithmSHA512):
-			return oidDigestAlgorithmECDSASHA512, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA1):
+			return OIDDigestAlgorithmECDSASHA1, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA256):
+			return OIDDigestAlgorithmECDSASHA256, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA384):
+			return OIDDigestAlgorithmECDSASHA384, nil
+		case OIDDigestAlg.Equal(OIDDigestAlgorithmSHA512):
+			return OIDDigestAlgorithmECDSASHA512, nil
 		}
 	}
 	return nil, fmt.Errorf("pkcs7: cannot convert encryption algorithm to oid, unknown public key type %T", pub)
@@ -173,11 +170,11 @@ func Parse(data []byte) (p7 *PKCS7, err error) {
 
 	// fmt.Printf("--> Content Type: %s", info.ContentType)
 	switch {
-	case info.ContentType.Equal(oidSignedData):
+	case info.ContentType.Equal(OIDSignedData):
 		return parseSignedData(info.Content.Bytes)
-	case info.ContentType.Equal(oidEnvelopedData):
+	case info.ContentType.Equal(OIDEnvelopedData):
 		return parseEnvelopedData(info.Content.Bytes)
-	case info.ContentType.Equal(oidEncryptedData):
+	case info.ContentType.Equal(OIDEncryptedData):
 		return parseEncryptedData(info.Content.Bytes)
 	}
 	return nil, ErrUnsupportedContentType

--- a/sign.go
+++ b/sign.go
@@ -18,24 +18,26 @@ type SignedData struct {
 	sd                  signedData
 	certs               []*x509.Certificate
 	data, messageDigest []byte
+	digestOid           asn1.ObjectIdentifier
 }
 
 // NewSignedData takes data and initializes a PKCS7 SignedData struct that is
-// ready to be signed via AddSigner.
+// ready to be signed via AddSigner. The digest algorithm is set to SHA1 by default
+// and can be changed by calling SetDigestAlgorithm.
 func NewSignedData(data []byte) (*SignedData, error) {
 	content, err := asn1.Marshal(data)
 	if err != nil {
 		return nil, err
 	}
 	ci := contentInfo{
-		ContentType: oidData,
+		ContentType: OIDData,
 		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
 	}
 	sd := signedData{
 		ContentInfo: ci,
 		Version:     1,
 	}
-	return &SignedData{sd: sd, data: data}, nil
+	return &SignedData{sd: sd, data: data, digestOid: OIDDigestAlgorithmSHA1}, nil
 }
 
 // SignerInfoConfig are optional values to include when adding a signer
@@ -90,6 +92,11 @@ type issuerAndSerial struct {
 	SerialNumber *big.Int
 }
 
+// SetDigestAlgorithm sets the digest algorithm to be used in the signing process
+func (sd *SignedData) SetDigestAlgorithm(d asn1.ObjectIdentifier) {
+	sd.digestOid = d
+}
+
 // AddSigner is a wrapper around AddSignerChain() that adds a signer without any parent.
 func (sd *SignedData) AddSigner(ee *x509.Certificate, pkey crypto.PrivateKey, config SignerInfoConfig) error {
 	var parents []*x509.Certificate
@@ -110,31 +117,22 @@ func (sd *SignedData) AddSigner(ee *x509.Certificate, pkey crypto.PrivateKey, co
 // section of the SignedData.SignerInfo, alongside the serial number of
 // the end-entity.
 func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKey, chain []*x509.Certificate, config SignerInfoConfig) error {
-	//oidDigestAlg, err := getDigestOIDForSignatureAlgorithm(ee.SignatureAlgorithm)
-	//if err != nil {
-	//	return err
-	//}
-	// FIXME https://bugzilla.mozilla.org/show_bug.cgi?id=1357815
-	// We currently pin the digest algorithm to SHA1 because firefox
-	// doesn't support SHA2 yet.
-	oidDigestAlg := oidDigestAlgorithmSHA1
-
-	sd.sd.DigestAlgorithmIdentifiers = append(sd.sd.DigestAlgorithmIdentifiers, pkix.AlgorithmIdentifier{Algorithm: oidDigestAlg})
-	hash, err := getHashForOID(oidDigestAlg)
+	sd.sd.DigestAlgorithmIdentifiers = append(sd.sd.DigestAlgorithmIdentifiers, pkix.AlgorithmIdentifier{Algorithm: sd.digestOid})
+	hash, err := getHashForOID(sd.digestOid)
 	if err != nil {
 		return err
 	}
 	h := hash.New()
 	h.Write(sd.data)
 	sd.messageDigest = h.Sum(nil)
-	oidEncryptionAlg, err := getOIDForEncryptionAlgorithm(pkey, oidDigestAlg)
+	encryptionOid, err := getOIDForEncryptionAlgorithm(pkey, sd.digestOid)
 	if err != nil {
 		return err
 	}
 	attrs := &attributes{}
-	attrs.Add(oidAttributeContentType, sd.sd.ContentInfo.ContentType)
-	attrs.Add(oidAttributeMessageDigest, sd.messageDigest)
-	attrs.Add(oidAttributeSigningTime, time.Now())
+	attrs.Add(OIDAttributeContentType, sd.sd.ContentInfo.ContentType)
+	attrs.Add(OIDAttributeMessageDigest, sd.messageDigest)
+	attrs.Add(OIDAttributeSigningTime, time.Now())
 	for _, attr := range config.ExtraSignedAttributes {
 		attrs.Add(attr.Type, attr.Value)
 	}
@@ -161,8 +159,8 @@ func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKe
 	}
 	signer := signerInfo{
 		AuthenticatedAttributes:   finalAttrs,
-		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: oidDigestAlg},
-		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: oidEncryptionAlg},
+		DigestAlgorithm:           pkix.AlgorithmIdentifier{Algorithm: sd.digestOid},
+		DigestEncryptionAlgorithm: pkix.AlgorithmIdentifier{Algorithm: encryptionOid},
 		IssuerAndSerialNumber:     ias,
 		EncryptedDigest:           signature,
 		Version:                   1,
@@ -182,7 +180,7 @@ func (sd *SignedData) AddCertificate(cert *x509.Certificate) {
 // Detach removes content from the signed data struct to make it a detached signature.
 // This must be called right before Finish()
 func (sd *SignedData) Detach() {
-	sd.sd.ContentInfo = contentInfo{ContentType: oidData}
+	sd.sd.ContentInfo = contentInfo{ContentType: OIDData}
 }
 
 // Finish marshals the content and its signers
@@ -193,7 +191,7 @@ func (sd *SignedData) Finish() ([]byte, error) {
 		return nil, err
 	}
 	outer := contentInfo{
-		ContentType: oidSignedData,
+		ContentType: OIDSignedData,
 		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: inner, IsCompound: true},
 	}
 	return asn1.Marshal(outer)
@@ -275,7 +273,7 @@ func DegenerateCertificate(cert []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	emptyContent := contentInfo{ContentType: oidData}
+	emptyContent := contentInfo{ContentType: OIDData}
 	sd := signedData{
 		Version:      1,
 		ContentInfo:  emptyContent,
@@ -287,7 +285,7 @@ func DegenerateCertificate(cert []byte) ([]byte, error) {
 		return nil, err
 	}
 	signedContent := contentInfo{
-		ContentType: oidSignedData,
+		ContentType: OIDSignedData,
 		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
 	}
 	return asn1.Marshal(signedContent)

--- a/verify.go
+++ b/verify.go
@@ -42,7 +42,7 @@ func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (e
 	if len(signer.AuthenticatedAttributes) > 0 {
 		// TODO(fullsailor): First check the content type match
 		var digest []byte
-		err := unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeMessageDigest, &digest)
+		err := unmarshalAttribute(signer.AuthenticatedAttributes, OIDAttributeMessageDigest, &digest)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (e
 		if err != nil {
 			return err
 		}
-		err = unmarshalAttribute(signer.AuthenticatedAttributes, oidAttributeSigningTime, &signingTime)
+		err = unmarshalAttribute(signer.AuthenticatedAttributes, OIDAttributeSigningTime, &signingTime)
 		if err == nil {
 			// signing time found, performing validity check
 			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
@@ -181,53 +181,53 @@ func (err *MessageDigestMismatchError) Error() string {
 
 func getSignatureAlgorithm(digestEncryption, digest pkix.AlgorithmIdentifier) (x509.SignatureAlgorithm, error) {
 	switch {
-	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA1):
+	case digestEncryption.Algorithm.Equal(OIDDigestAlgorithmECDSASHA1):
 		return x509.ECDSAWithSHA1, nil
-	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA256):
+	case digestEncryption.Algorithm.Equal(OIDDigestAlgorithmECDSASHA256):
 		return x509.ECDSAWithSHA256, nil
-	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA384):
+	case digestEncryption.Algorithm.Equal(OIDDigestAlgorithmECDSASHA384):
 		return x509.ECDSAWithSHA384, nil
-	case digestEncryption.Algorithm.Equal(oidDigestAlgorithmECDSASHA512):
+	case digestEncryption.Algorithm.Equal(OIDDigestAlgorithmECDSASHA512):
 		return x509.ECDSAWithSHA512, nil
-	case digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSA),
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSASHA1),
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSASHA256),
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSASHA384),
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmRSASHA512):
+	case digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSA),
+		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA1),
+		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA256),
+		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA384),
+		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA512):
 		switch {
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA1):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1):
 			return x509.SHA1WithRSA, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA256):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA256):
 			return x509.SHA256WithRSA, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA384):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA384):
 			return x509.SHA384WithRSA, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA512):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA512):
 			return x509.SHA512WithRSA, nil
 		default:
 			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
 				digest.Algorithm.String(), digestEncryption.Algorithm.String())
 		}
-	case digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmDSA):
+	case digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmDSA):
 		switch {
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA1):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1):
 			return x509.DSAWithSHA1, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA256):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA256):
 			return x509.DSAWithSHA256, nil
 		default:
 			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
 				digest.Algorithm.String(), digestEncryption.Algorithm.String())
 		}
-	case digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP256),
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP384),
-		digestEncryption.Algorithm.Equal(oidEncryptionAlgorithmECDSAP521):
+	case digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmECDSAP256),
+		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmECDSAP384),
+		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmECDSAP521):
 		switch {
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA1):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1):
 			return x509.ECDSAWithSHA1, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA256):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA256):
 			return x509.ECDSAWithSHA256, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA384):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA384):
 			return x509.ECDSAWithSHA384, nil
-		case digest.Algorithm.Equal(oidDigestAlgorithmSHA512):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA512):
 			return x509.ECDSAWithSHA512, nil
 		default:
 			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",


### PR DESCRIPTION
This patch add a new method SetDigestAlgorithm to set the digest
algorihm used when signing data. It also exports all the OIDs to make
them usable outside the package, which artificially inflates the size
of this change.