### PR TITLE
Add support for creation of detached signature from pre-calculated data digest

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -118,7 +118,7 @@ func (sd *SignedData) SetDigestAlgorithm(d asn1.ObjectIdentifier) error {
 		sd.digestOid = d
 		return nil
 	}
-	return fmt.Errorf("digest algorithm was already set")
+	return errors.New("digest algorithm was already set")
 }
 
 // SetEncryptionAlgorithm sets the encryption algorithm to be used in the signing process.


### PR DESCRIPTION
**ABSTRACT**
The library only allows to create a PKCS#7 signature from the content data (as a []byte), even when the signature is detached and no content data ends up in the final signature.
With minimal, backwards compatible modifications it can be extended to allow the signature of a pre-calculated content data digest, given the hash algorithm. 
**RATIONALE**
This is handy when one wants to calculate a digest on one machine (e.g. the server) and apply the signature elsewhere (e.g. a client or another server), limiting the data transfer to the digest and algorithm information.
**CODE MODIFICATIONS**
I added a new "constructor" to initialise the SignedData from digest and algorithm instead of delegating the creation of these fields to the final signature phases: moreover I modified slightly how some of the other functions work in order to keep the internal data structures consistent (essentially wherever the content data, the digest or the digest algorithm are manipulated). 
**TESTS**
In order to show that this new approach produces exactly the same results as a detached signature of user-provided data, I modified the ExampleSIgnedData() example duplicating the signature procedure and comparing the results, which happen to be equal because no time attributed is signed along with the data. The example digest algorithm is the default (SHA1), even though it would probably be advisable to move on to SHA256.

I ran the ExampleSignedData() as a test to verify it succeeds.
