### PR TITLE
Allow specific sign time in VerifyWithChain

### DIFF
--- a/sign_test.go
+++ b/sign_test.go
@@ -77,7 +77,7 @@ func TestSign(t *testing.T) {
 					if !bytes.Equal(content, p7.Content) {
 						t.Errorf("test %s/%s/%s: content was not found in the parsed data:\n\tExpected: %s\n\tActual: %s", sigalgroot, sigalginter, sigalgsigner, content, p7.Content)
 					}
-					if err := p7.VerifyWithChain(truststore); err != nil {
+					if err := p7.VerifyWithChain(truststore, nil); err != nil {
 						t.Errorf("test %s/%s/%s: cannot verify signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
 					if !signerDigest.Equal(p7.Signers[0].DigestAlgorithm.Algorithm) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -299,7 +299,7 @@ func TestVerifyFirefoxAddon(t *testing.T) {
 	p7.Content = FirefoxAddonContent
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(FirefoxAddonRootCert)
-	if err := p7.VerifyWithChain(certPool); err != nil {
+	if err := p7.VerifyWithChain(certPool, nil); err != nil {
 		t.Errorf("Verify failed with error: %v", err)
 	}
 	// Verify the certificate chain to make sure the identified root
@@ -582,7 +582,7 @@ but that's not what ships are built for.
 				if err != nil {
 					t.Fatalf("Parse encountered unexpected error: %v", err)
 				}
-				if err := p7.VerifyWithChain(truststore); err != nil {
+				if err := p7.VerifyWithChain(truststore, nil); err != nil {
 					t.Fatalf("Verify failed with error: %v", err)
 				}
 				// Verify the certificate chain to make sure the identified root


### PR DESCRIPTION
Something we might got receipt that was signed with a valid but expired certificate. Add an optional time into VerifyWithChain params to allow to specific sign time.