### PR TITLE
Fix travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-    - "1.9"
-    - "1.10"
+    - "1.11"
+    - "1.12"
+    - "1.13"
     - tip
 before_install:
     - make gettools

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: vet unused gosimple staticcheck test
+all: vet staticcheck test
 
 test:
 	go test -covermode=count -coverprofile=coverage.out .
@@ -11,12 +11,6 @@ vet:
 
 lint:
 	golint .
-
-unused:
-	unused .
-
-gosimple:
-	gosimple .
 
 staticcheck:
 	staticcheck .

--- a/ber.go
+++ b/ber.go
@@ -184,7 +184,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		if numberOfBytes == 4 && (int)(ber[offset]) > 0x7F {
 			return nil, 0, errors.New("ber2der: BER tag length is negative")
 		}
-		if 0x0 == (int)(ber[offset]) {
+		if (int)(ber[offset]) == 0x0 {
 			return nil, 0, errors.New("ber2der: BER tag length has leading zero")
 		}
 		debugprint("--> (compute length) indicator byte: %x\n", l)

--- a/decrypt.go
+++ b/decrypt.go
@@ -30,10 +30,10 @@ func (p7 *PKCS7) Decrypt(cert *x509.Certificate, pkey crypto.PrivateKey) ([]byte
 	if recipient.EncryptedKey == nil {
 		return nil, errors.New("pkcs7: no enveloped recipient for provided certificate")
 	}
-	switch pkey.(type) {
+	switch pkey := pkey.(type) {
 	case *rsa.PrivateKey:
 		var contentKey []byte
-		contentKey, err := rsa.DecryptPKCS1v15(rand.Reader, pkey.(*rsa.PrivateKey), recipient.EncryptedKey)
+		contentKey, err := rsa.DecryptPKCS1v15(rand.Reader, pkey, recipient.EncryptedKey)
 		if err != nil {
 			return nil, err
 		}

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -115,7 +115,7 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			CommonName:   name,
 			Organization: []string{"Acme Co"},
 		},
-		NotBefore:   time.Now(),
+		NotBefore:   time.Now().Add(-1 * time.Second),
 		NotAfter:    time.Now().AddDate(1, 0, 0),
 		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageEmailProtection},

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -115,7 +115,7 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			CommonName:   name,
 			Organization: []string{"Acme Co"},
 		},
-		NotBefore:   time.Now().Add(-1 * time.Second),
+		NotBefore:   time.Now().Add(-1 *time.Second),
 		NotAfter:    time.Now().AddDate(1, 0, 0),
 		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageEmailProtection},
@@ -271,13 +271,13 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		}
 	case *dsa.PrivateKey:
 		pub := &priv.(*dsa.PrivateKey).PublicKey
-		switch issuerKey.(type) {
+		switch issuerKey := issuerKey.(type) {
 		case *rsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, pub, issuerKey.(*rsa.PrivateKey))
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, pub, issuerKey)
 		case *ecdsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey.(*ecdsa.PrivateKey))
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey)
 		case *dsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey.(*dsa.PrivateKey))
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey)
 		}
 	}
 	if err != nil {

--- a/sign.go
+++ b/sign.go
@@ -212,11 +212,11 @@ func (sd *SignedData) SignWithoutAttr(ee *x509.Certificate, pkey crypto.PrivateK
 	h := hash.New()
 	h.Write(sd.data)
 	sd.messageDigest = h.Sum(nil)
-	switch pkey.(type) {
+	switch pkey := pkey.(type) {
 	case *dsa.PrivateKey:
 		// dsa doesn't implement crypto.Signer so we make a special case
 		// https://github.com/golang/go/issues/27889
-		r, s, err := dsa.Sign(rand.Reader, pkey.(*dsa.PrivateKey), sd.messageDigest)
+		r, s, err := dsa.Sign(rand.Reader, pkey, sd.messageDigest)
 		if err != nil {
 			return err
 		}
@@ -360,9 +360,9 @@ func signAttributes(attrs []attribute, pkey crypto.PrivateKey, digestAlg crypto.
 
 	// dsa doesn't implement crypto.Signer so we make a special case
 	// https://github.com/golang/go/issues/27889
-	switch pkey.(type) {
+	switch pkey := pkey.(type) {
 	case *dsa.PrivateKey:
-		r, s, err := dsa.Sign(rand.Reader, pkey.(*dsa.PrivateKey), hash)
+		r, s, err := dsa.Sign(rand.Reader, pkey, hash)
 		if err != nil {
 			return nil, err
 		}

--- a/verify_test.go
+++ b/verify_test.go
@@ -541,12 +541,12 @@ but that's not what ships are built for.
 				}
 				var derKey []byte
 				priv := *signerCert.PrivateKey
-				switch priv.(type) {
+				switch priv := priv.(type) {
 				case *rsa.PrivateKey:
-					derKey = x509.MarshalPKCS1PrivateKey(priv.(*rsa.PrivateKey))
+					derKey = x509.MarshalPKCS1PrivateKey(priv)
 					pem.Encode(fd, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: derKey})
 				case *ecdsa.PrivateKey:
-					derKey, err = x509.MarshalECPrivateKey(priv.(*ecdsa.PrivateKey))
+					derKey, err = x509.MarshalECPrivateKey(priv)
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION
CI is failing because of system time discrepancies between the test suite and OpenSSL. This attempts to fix this issue by allowing for a second of grace before signature time.