### PR TITLE
Fix failure to parse enveloped data

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -35,7 +35,7 @@ type recipientInfo struct {
 type encryptedContentInfo struct {
 	ContentType                asn1.ObjectIdentifier
 	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
-	EncryptedContent           asn1.RawValue `asn1:"tag:0,optional,explicit"`
+	EncryptedContent           asn1.RawValue `asn1:"tag:0,optional"`
 }
 
 const (


### PR DESCRIPTION
When handling data encrypted by the eyaml ruby gem, I ran into an issue where I got the following error on calling `PKCS7.Decrypt()`: `invalid data len 0`

Turns out this is due to the `EncryptedContent` field having the `explicit` tag set while in actual fact this field is optional (see https://tools.ietf.org/html/rfc2315#section-10.1).

Our neighbors at fullsailor/pkcs7 fixed this in https://github.com/fullsailor/pkcs7/commit/cddbb99c85db9a927ad8f22bedf5891e1c7fe934