### PR TITLE
Compatibility with Microsoft Azure certificates.

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -199,13 +199,19 @@ func getSignatureAlgorithm(digestEncryption, digest pkix.AlgorithmIdentifier) (x
 		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA384),
 		digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA512):
 		switch {
-		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1),
+			// Some Microsoft issued certificates use the general RSA algorithm
+			// for the encrypt OID and the digest+algorithm OID for the digest.
+			digest.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA1):
 			return x509.SHA1WithRSA, nil
-		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA256):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA256),
+			digest.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA256):
 			return x509.SHA256WithRSA, nil
-		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA384):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA384),
+			digest.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA384):
 			return x509.SHA384WithRSA, nil
-		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA512):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA512),
+			digest.Algorithm.Equal(OIDEncryptionAlgorithmRSASHA512):
 			return x509.SHA512WithRSA, nil
 		default:
 			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
@@ -214,7 +220,8 @@ func getSignatureAlgorithm(digestEncryption, digest pkix.AlgorithmIdentifier) (x
 	case digestEncryption.Algorithm.Equal(OIDDigestAlgorithmDSA),
 		digestEncryption.Algorithm.Equal(OIDDigestAlgorithmDSASHA1):
 		switch {
-		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1):
+		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA1),
+			digest.Algorithm.Equal(OIDDigestAlgorithmDSASHA1):
 			return x509.DSAWithSHA1, nil
 		case digest.Algorithm.Equal(OIDDigestAlgorithmSHA256):
 			return x509.DSAWithSHA256, nil


### PR DESCRIPTION
Some PKCS7 responses from Microsoft Azure's instance metadata service
(IMDS)[0] use the "encrypt+digest" OID for the digest OID.

This change allows verification of these signatures.

[0] https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux#attested-data