### PR TITLE
fixes ber decoding with longer certs

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -175,7 +175,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	if offset > berLen {
 		return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
 	}
-	hack := 0
+	indefinite := false
 	if l > 0x80 {
 		numberOfBytes := (int)(l & 0x7F)
 		if numberOfBytes > 4 { // int is only guaranteed to be 32bit
@@ -197,14 +197,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 			}
 		}
 	} else if l == 0x80 {
-		// find length by searching content
-		markerIndex := bytes.LastIndex(ber[offset:], []byte{0x0, 0x0})
-		if markerIndex == -1 {
-			return nil, 0, errors.New("ber2der: Invalid BER format")
-		}
-		length = markerIndex
-		hack = 2
-		debugprint("--> (compute length) marker found at offset: %d\n", markerIndex+offset)
+		indefinite = true
 	} else {
 		length = (int)(l)
 	}
@@ -220,6 +213,9 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	debugprint("--> content end   : %d\n", contentEnd)
 	debugprint("--> content       : % X\n", ber[offset:contentEnd])
 	var obj asn1Object
+	if indefinite && kind == 0 {
+		return nil, 0, errors.New("ber2der: Indefinite form tag must have constructed encoding")
+	}
 	if kind == 0 {
 		obj = asn1Primitive{
 			tagBytes: ber[tagStart:tagEnd],
@@ -228,14 +224,25 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		}
 	} else {
 		var subObjects []asn1Object
-		for offset < contentEnd {
+		for offset < contentEnd || indefinite {
 			var subObj asn1Object
 			var err error
-			subObj, offset, err = readObject(ber[:contentEnd], offset)
+			subObj, offset, err = readObject(ber, offset)
 			if err != nil {
 				return nil, 0, err
 			}
 			subObjects = append(subObjects, subObj)
+
+			if indefinite {
+				terminated, err := isIndefiniteTermination(ber, offset)
+				if err != nil {
+					return nil, 0, err
+				}
+
+				if terminated {
+					break
+				}
+			}
 		}
 		obj = asn1Structured{
 			tagBytes: ber[tagStart:tagEnd],
@@ -243,7 +250,19 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 		}
 	}
 
-	return obj, contentEnd + hack, nil
+	if indefinite {
+		contentEnd = offset + 2
+	}
+
+	return obj, contentEnd, nil
+}
+
+func isIndefiniteTermination(ber []byte, offset int) (bool, error) {
+	if len(ber) - offset < 2 {
+		return false, errors.New("ber2der: Invalid BER format")
+	}
+
+	return bytes.Index(ber[offset:], []byte{0x0, 0x0}) == 0, nil
 }
 
 func debugprint(format string, a ...interface{}) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module go.mozilla.org/pkcs7
+module github.com/manavk-p/pkcs7
 
 go 1.11


### PR DESCRIPTION
Allows for longer certs, such as some AWS certs, to be decoded properly. Taken from https://github.com/fullsailor/pkcs7/pull/17