### PR TITLE
add VerifyWithChainAtTime

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -18,8 +18,12 @@ func (p7 *PKCS7) Verify() (err error) {
 }
 
 // VerifyWithChain checks the signatures of a PKCS7 object.
-// If truststore is not nil, it also verifies the chain of trust of the end-entity
-// signer cert to one of the root in the truststore.
+//
+// If truststore is not nil, it also verifies the chain of trust of
+// the end-entity signer cert to one of the roots in the
+// truststore. When the PKCS7 object includes the signing time
+// authenticated attr verifies the chain at that time and UTC now
+// otherwise.
 func (p7 *PKCS7) VerifyWithChain(truststore *x509.CertPool) (err error) {
 	if len(p7.Signers) == 0 {
 		return errors.New("pkcs7: Message has no signers")
@@ -30,6 +34,81 @@ func (p7 *PKCS7) VerifyWithChain(truststore *x509.CertPool) (err error) {
 		}
 	}
 	return nil
+}
+
+// VerifyWithChainAtTime checks the signatures of a PKCS7 object.
+//
+// If truststore is not nil, it also verifies the chain of trust of
+// the end-entity signer cert to a root in the truststore at
+// currentTime. It does not use the signing time authenticated
+// attribute.
+func (p7 *PKCS7) VerifyWithChainAtTime(truststore *x509.CertPool, currentTime time.Time) (err error) {
+	if len(p7.Signers) == 0 {
+		return errors.New("pkcs7: Message has no signers")
+	}
+	for _, signer := range p7.Signers {
+		if err := verifySignatureAtTime(p7, signer, truststore, currentTime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifySignatureAtTime(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool, currentTime time.Time) (err error) {
+	signedData := p7.Content
+	ee := getCertFromCertsByIssuerAndSerial(p7.Certificates, signer.IssuerAndSerialNumber)
+	if ee == nil {
+		return errors.New("pkcs7: No certificate for signer")
+	}
+	if len(signer.AuthenticatedAttributes) > 0 {
+		// TODO(fullsailor): First check the content type match
+		var (
+			digest      []byte
+			signingTime time.Time
+		)
+		err := unmarshalAttribute(signer.AuthenticatedAttributes, OIDAttributeMessageDigest, &digest)
+		if err != nil {
+			return err
+		}
+		hash, err := getHashForOID(signer.DigestAlgorithm.Algorithm)
+		if err != nil {
+			return err
+		}
+		h := hash.New()
+		h.Write(p7.Content)
+		computed := h.Sum(nil)
+		if subtle.ConstantTimeCompare(digest, computed) != 1 {
+			return &MessageDigestMismatchError{
+				ExpectedDigest: digest,
+				ActualDigest:   computed,
+			}
+		}
+		signedData, err = marshalAttributes(signer.AuthenticatedAttributes)
+		if err != nil {
+			return err
+		}
+		err = unmarshalAttribute(signer.AuthenticatedAttributes, OIDAttributeSigningTime, &signingTime)
+		if err == nil {
+			// signing time found, performing validity check
+			if signingTime.After(ee.NotAfter) || signingTime.Before(ee.NotBefore) {
+				return fmt.Errorf("pkcs7: signing time %q is outside of certificate validity %q to %q",
+					signingTime.Format(time.RFC3339),
+					ee.NotBefore.Format(time.RFC3339),
+					ee.NotAfter.Format(time.RFC3339))
+			}
+		}
+	}
+	if truststore != nil {
+		_, err = verifyCertChain(ee, p7.Certificates, truststore, currentTime)
+		if err != nil {
+			return err
+		}
+	}
+	sigalg, err := getSignatureAlgorithm(signer.DigestEncryptionAlgorithm, signer.DigestAlgorithm)
+	if err != nil {
+		return err
+	}
+	return ee.CheckSignature(sigalg, signedData, signer.EncryptedDigest)
 }
 
 func verifySignature(p7 *PKCS7, signer signerInfo, truststore *x509.CertPool) (err error) {

--- a/verify_test_dsa.go
+++ b/verify_test_dsa.go
@@ -156,7 +156,6 @@ CWCGSAFlAwQDAgUAAzAAMC0CFQCIgQtrZZ9hdZG1ROhR5hc8nYEmbgIUAIlgC688
 qzy/7yePTlhlpj+ahMM=
 -----END CERTIFICATE-----`)
 
-
 type DSATestFixture struct {
 	Input       []byte
 	Certificate *x509.Certificate


### PR DESCRIPTION
refs: https://github.com/mozilla-services/autograph/pull/722 where we'd like to use this module to verify PK7 Addon signatures at a certain time.

Changes:
* Add `VerifyWithChainAtTime` method that takes an additional `currentTime` parameter to set a time to verify the chain at (like https://pkg.go.dev/crypto/x509#VerifyOptions except we don't special case the Unix zero timestamp)
* Changes `VerifyWithChain` to call the new method with currentTime set to UTC now (the old signTime)

NB: when the PK7 document contained authenticated attributes [this line](https://github.com/mozilla-services/pkcs7/compare/master...mozilla-services:verify-at-time?expand=1#diff-32870c78c32d49e31ad4f22eaeac957ae6b988eea6fc937c9dba68035ac0d1b6L66) appears to overwrite `signingTime`, which as then used as the verification time. ~~I don't know if we'd want to recover that behavior.~~ We definitely do to avoid introducing a breaking change. On `master` `TestVerifyFirefoxAddon` verifies at the signing time `2016-08-17 20:04:58 +0000 UTC` but uses UTC now on this branch. I think the behavior we want is:

* `VerifyWithChain` is unchanged. It verifies using the authenticated `OIDAttributeSigningTime`  attr when available and UTC now otherwise
* `VerifyWithChainAtTime` always verifies at the provided `currentTime` regardless of the signingTime attr

Background:

* #24 is for something similar, but it [adds a signTime arg](https://github.com/mozilla-services/pkcs7/pull/24/files#diff-32870c78c32d49e31ad4f22eaeac957ae6b988eea6fc937c9dba68035ac0d1b6R26) to `VerifyWithChain` introducing a breaking change
* in response to ulfr's feedback on that PR https://github.com/mozilla-services/pkcs7/pull/24#issuecomment-695172995 discusses using an options struct, but that's more than I'm willing to tackle right now and I think we just need the verification time param

r? @ajvb @kkleemola 