### PR TITLE
readme: make CI badge a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pkcs7
 
 [![GoDoc](https://godoc.org/go.mozilla.org/pkcs7?status.svg)](https://godoc.org/go.mozilla.org/pkcs7)
-[![Build Status](https://github.com/mozilla-services/pkcs7/workflows/CI/badge.svg?branch=master&event=push)
+[![Build Status](https://github.com/mozilla-services/pkcs7/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/mozilla-services/pkcs7/actions/workflows/ci.yml?query=branch%3Amaster+event%3Apush)
 
 pkcs7 implements parsing and creating signed and enveloped messages.
 


### PR DESCRIPTION
The current CI badge includes a typo and links to the svg file. Link to the CI runs page instead.