### PR TITLE
New SignedData with content type and without certificates

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -34,6 +34,26 @@ func NewSignedData(data []byte) (*SignedData, error) {
 	return signedData, nil
 }
 
+// One of the practical use cases of NewSignedDataWithContentType is:
+// Pasted from RFC 3161
+//
+// 2.4.2. Response Format
+// TimeStampToken ::= ContentInfo
+//      -- contentType is id-signedData ([CMS])
+//      -- content is SignedData ([CMS])
+//
+// The fields of type EncapsulatedContentInfo of the SignedData
+// construct have the following meanings:
+//
+// eContentType is an object identifier that uniquely specifies the
+// content type.  For a time-stamp token it is defined as:
+//
+// id-ct-TSTInfo  OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+// us(840) rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) ct(1) 4}
+//
+// eContent is the content itself, carried as an octet string.
+// The eContent SHALL be the DER-encoded value of TSTInfo.
+
 // NewSignedDataWithContentType takes content type and data and initializes a PKCS7 SignedData struct that is
 // ready to be signed via AddSigner. The digest algorithm is set to SHA1 by default
 // and can be changed by calling SetDigestAlgorithm.
@@ -131,7 +151,28 @@ func (sd *SignedData) SetEncryptionAlgorithm(d asn1.ObjectIdentifier) {
 // AddSigner is a wrapper around AddSignerChain() that adds a signer without any parent.
 func (sd *SignedData) AddSigner(ee *x509.Certificate, pkey crypto.PrivateKey, config SignerInfoConfig) error {
 	var parents []*x509.Certificate
-	return sd.AddSignerChain(ee, pkey, parents, config)
+	return sd.addSignerChain(ee, pkey, parents, config, true)
+}
+
+// One of the practical use cases of AddSignerNoChain is:
+// Pasted from RFC 3161
+
+// 2.4.1. Request Format
+// If the certReq field is present and set to true, the TSA's public key
+// certificate that is referenced by the ESSCertID identifier inside a
+// SigningCertificate attribute in the response MUST be provided by the
+// TSA in the certificates field from the SignedData structure in that
+// response.  That field may also contain other certificates.
+
+// If the certReq field is missing or if the certReq field is present
+// and set to false then the certificates field from the SignedData
+// structure MUST not be present in the response.
+
+// AddSignerNoChain is a wrapper around AddSignerChain() that adds a signer without any parent.
+// Use this method, if no certificate needs to be placed in SignedData certificates
+func (sd *SignedData) AddSignerNoChain(ee *x509.Certificate, pkey crypto.PrivateKey, config SignerInfoConfig) error {
+	var parents []*x509.Certificate
+	return sd.addSignerChain(ee, pkey, parents, config, false)
 }
 
 // AddSignerChain signs attributes about the content and adds certificates
@@ -143,6 +184,10 @@ func (sd *SignedData) AddSigner(ee *x509.Certificate, pkey crypto.PrivateKey, co
 // The signature algorithm used to hash the data is the one of the end-entity
 // certificate.
 func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKey, parents []*x509.Certificate, config SignerInfoConfig) error {
+	return sd.addSignerChain(ee, pkey, parents, config, true)
+}
+
+func (sd *SignedData) addSignerChain(ee *x509.Certificate, pkey crypto.PrivateKey, parents []*x509.Certificate, config SignerInfoConfig, includeCertificates bool) error {
 	// Following RFC 2315, 9.2 SignerInfo type, the distinguished name of
 	// the issuer of the end-entity signer is stored in the issuerAndSerialNumber
 	// section of the SignedData.SignerInfo, alongside the serial number of
@@ -207,9 +252,12 @@ func (sd *SignedData) AddSignerChain(ee *x509.Certificate, pkey crypto.PrivateKe
 		EncryptedDigest:           signature,
 		Version:                   1,
 	}
-	sd.certs = append(sd.certs, ee)
-	if len(parents) > 0 {
-		sd.certs = append(sd.certs, parents...)
+
+	if includeCertificates {
+		sd.certs = append(sd.certs, ee)
+		if len(parents) > 0 {
+			sd.certs = append(sd.certs, parents...)
+		}
 	}
 	sd.sd.SignerInfos = append(sd.sd.SignerInfos, signer)
 	return nil

--- a/sign.go
+++ b/sign.go
@@ -27,12 +27,31 @@ type SignedData struct {
 // ready to be signed via AddSigner. The digest algorithm is set to SHA1 by default
 // and can be changed by calling SetDigestAlgorithm.
 func NewSignedData(data []byte) (*SignedData, error) {
+	signedData, err := newSignedData(OIDData, data)
+	if err != nil {
+		return nil, err
+	}
+	return signedData, nil
+}
+
+// NewSignedDataWithContentType takes content type and data and initializes a PKCS7 SignedData struct that is
+// ready to be signed via AddSigner. The digest algorithm is set to SHA1 by default
+// and can be changed by calling SetDigestAlgorithm.
+func NewSignedDataWithContentType(contentType asn1.ObjectIdentifier, data []byte) (*SignedData, error) {
+	signedData, err := newSignedData(contentType, data)
+	if err != nil {
+		return nil, err
+	}
+	return signedData, nil
+}
+
+func newSignedData(contentType asn1.ObjectIdentifier, data []byte) (*SignedData, error) {
 	content, err := asn1.Marshal(data)
 	if err != nil {
 		return nil, err
 	}
 	ci := contentInfo{
-		ContentType: OIDData,
+		ContentType: contentType,
 		Content:     asn1.RawValue{Class: 2, Tag: 0, Bytes: content, IsCompound: true},
 	}
 	sd := signedData{

--- a/sign_test.go
+++ b/sign_test.go
@@ -186,6 +186,32 @@ func ExampleSignedData() {
 	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
 }
 
+func TestSignedDataWithContentType(t *testing.T) {
+	// generate a signing cert or load a key pair
+	cert, err := createTestCertificate(x509.SHA256WithRSA)
+	if err != nil {
+		fmt.Printf("Cannot create test certificates: %s", err)
+	}
+
+	// Initialize a SignedData struct with content to be signed
+	signedData, err := NewSignedDataWithContentType(asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 1, 4}, []byte("Example data to be signed"))
+	if err != nil {
+		fmt.Printf("Cannot initialize signed data: %s", err)
+	}
+
+	// Add the signing cert and private key
+	if err := signedData.AddSigner(cert.Certificate, cert.PrivateKey, SignerInfoConfig{}); err != nil {
+		fmt.Printf("Cannot add signer: %s", err)
+	}
+
+	// Finish() to obtain the signature bytes
+	detachedSignature, err := signedData.Finish()
+	if err != nil {
+		fmt.Printf("Cannot finish signing data: %s", err)
+	}
+	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
+}
+
 func TestUnmarshalSignedAttribute(t *testing.T) {
 	cert, err := createTestCertificate(x509.SHA512WithRSA)
 	if err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -200,8 +200,8 @@ func TestSignedDataWithContentType(t *testing.T) {
 	}
 
 	// Add the signing cert and private key
-	if err := signedData.AddSigner(cert.Certificate, cert.PrivateKey, SignerInfoConfig{}); err != nil {
-		fmt.Printf("Cannot add signer: %s", err)
+	if err := signedData.AddSignerNoChain(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{}); err != nil {
+		t.Fatalf("Cannot add signer: %s", err)
 	}
 
 	// Finish() to obtain the signature bytes


### PR DESCRIPTION
This introduces two use cases that are required for time stamping (RFC3161).

See also the included documentation.

Example usages:
https://github.com/digitorus/timestamp/blob/master/timestamp.go#L595
https://github.com/digitorus/timestamp/blob/master/timestamp.go#L617
