### PR TITLE
SetContentType of SignedData

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -280,6 +280,12 @@ func (sd *SignedData) AddCertificate(cert *x509.Certificate) {
 	sd.certs = append(sd.certs, cert)
 }
 
+// SetContentType sets the content type of the SignedData. For example to specify the
+// content type of a time-stamp token according to RFC 3161 section 2.4.2.
+func (sd *SignedData) SetContentType(contentType asn1.ObjectIdentifier) {
+	sd.sd.ContentInfo.ContentType = contentType
+}
+
 // Detach removes content from the signed data struct to make it a detached signature.
 // This must be called right before Finish()
 func (sd *SignedData) Detach() {


### PR DESCRIPTION
Setting the content type of signed data is required to create an RFC3161 compliant timestamp response:

https://www.rfc-editor.org/rfc/rfc3161.html#section-2.4.2

> A TimeStampToken is as follows.  It is defined as a ContentInfo
>    ([[CMS](https://www.rfc-editor.org/rfc/rfc3161.html#ref-CMS)]) and SHALL encapsulate a signed data content type.
> 
>    TimeStampToken ::= ContentInfo
>      -- contentType is id-signedData ([[CMS](https://www.rfc-editor.org/rfc/rfc3161.html#ref-CMS)])
>      -- content is SignedData ([[CMS](https://www.rfc-editor.org/rfc/rfc3161.html#ref-CMS)])
> 
> The fields of type EncapsulatedContentInfo of the SignedData
>    construct have the following meanings:
> 
>    eContentType is an object identifier that uniquely specifies the
>    content type.  For a time-stamp token it is defined as:
> 
>    id-ct-TSTInfo  OBJECT IDENTIFIER ::= { iso(1) member-body(2)
>    us(840) rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) ct(1) 4}
